### PR TITLE
Sky Spy mesh output, BLE fixes, FlockYou improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 # firmware/*.bin
 __pycache__/
 .venv/
+nul
+package.json
+package-lock.json
+src/idf_component.yml
+src/idf_component.yml.orig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Note: Mode IDs 3 is skipped intentionally.
 - **LED:** GPIO 21 has inverted logic (LOW = ON). Optional NeoPixel on GPIO 4.
 - **Embedded HTML:** Stored as `PROGMEM` raw string literals with `%PLACEHOLDER%` template substitution.
 - **Device cooldowns:** Detection modes use timed cooldowns (3s or 30s) to prevent alert spam on the same device.
-- **Sky Spy differs:** Uses WiFi promiscuous mode (not BLE) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`.
+- **Sky Spy differs:** Uses WiFi promiscuous mode (+ BLE passive scan) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`. Outputs full JSON on USB Serial (every detection) and compact human-readable messages on Serial1 pins 5/6 (throttled to 5s) for Heltec LoRa/Meshtastic mesh forwarding. Serial1 is harmless when no mesh hardware is connected.
 
 ### Hardware
 
@@ -100,6 +100,8 @@ Note: Mode IDs 3 is skipped intentionally.
 | 0 | BOOT button (hold 2s → return to selector) |
 | 3 | Piezo buzzer (PWM, inverted logic) |
 | 4 | NeoPixel LED (optional) |
+| 5 / D4 | Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy) |
+| 6 / D5 | Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy) |
 | 21 | Onboard LED (inverted logic) |
 
 ### Dependencies (managed by PlatformIO)

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -151,7 +151,6 @@ static Adafruit_NeoPixel fyPixel(1, FY_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
 static bool fyPixelAlertMode = false;
 static unsigned long fyPixelAlertStart = 0;
 static unsigned long fyLastBleScan = 0;
-static bool fyTriggered = false;
 static bool fyDeviceInRange = false;
 static unsigned long fyLastDetTime = 0;
 static unsigned long fyLastHB = 0;
@@ -610,9 +609,8 @@ class FYBLECallbacks : public NimBLEAdvertisedDeviceCallbacks {
                        method, addrStr.c_str(), name.c_str(), rssi, gpsBuf);
             }
 
-            if (!fyTriggered) {
-                fyTriggered = true;
-                fyDetectBeep();
+            if (idx >= 0 && fyDet[idx].count == 1) {
+                fyDetectBeep();  // Flash + sound on every NEW device
             }
             fyDeviceInRange = true;
             fyLastDetTime = millis();
@@ -1090,7 +1088,6 @@ static void fySetupServer() {
         if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(200)) == pdTRUE) {
             fyDetCount = 0;
             memset(fyDet, 0, sizeof(fyDet));
-            fyTriggered = false;
             fyDeviceInRange = false;
             xSemaphoreGive(fyMutex);
         }
@@ -1209,7 +1206,6 @@ void loop() {
         if (millis() - fyLastDetTime >= 30000) {
             printf("[FLOCK-YOU] Device out of range - stopping heartbeat\n");
             fyDeviceInRange = false;
-            fyTriggered = false;
         }
     }
 

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -287,18 +287,14 @@ static uint32_t fyHsvToRgb(uint16_t h, uint8_t s, uint8_t v) {
 // Idle: slow purple breathing (hue 270)
 static void fyPixelBreathing() {
     static unsigned long lastUpdate = 0;
-    static float brightness = 0.0;
-    static bool increasing = true;
     if (millis() - lastUpdate < 20) return;
     lastUpdate = millis();
-    if (increasing) {
-        brightness += 0.02;
-        if (brightness >= 1.0) { brightness = 1.0; increasing = false; }
-    } else {
-        brightness -= 0.02;
-        if (brightness <= 0.1) { brightness = 0.1; increasing = true; }
-    }
-    uint32_t color = fyHsvToRgb(270, 255, (uint8_t)(FY_NEOPIXEL_BRIGHTNESS * brightness));
+    // Time-based sine wave: smooth regardless of loop speed
+    // 1500ms full cycle (~0.67Hz breathing rate)
+    float phase = (millis() % 1500) / 1500.0f * 2.0f * 3.14159f;
+    float val = (sinf(phase) + 1.0f) / 2.0f;  // 0.0 – 1.0
+    uint8_t v = 15 + (uint8_t)(val * 45);      // 15 – 60 range
+    uint32_t color = fyHsvToRgb(270, 255, v);
     fyPixel.setPixelColor(0, color);
     fyPixel.show();
 }

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -209,10 +209,12 @@ void send_json_fast(const id_data *UAV) {
 
 void bleScanTask(void *parameter) {
   for (;;) {
+    // Short BLE scan with long gap to minimize WiFi promiscuous interference.
+    // ESP32 shares one 2.4GHz radio for BLE and WiFi; aggressive BLE scanning
+    // starves WiFi promiscuous mode, causing missed drone detections.
     NimBLEScanResults foundDevices = pBLEScan->start(1, false);
     pBLEScan->clearResults();
-    // No flag checking needed - BLE callback handles buzzer triggering
-    delay(100);
+    delay(10000);  // 10s gap between scans — gives WiFi promiscuous priority
   }
 }
 
@@ -425,7 +427,7 @@ void setup() {
   NimBLEDevice::init("DroneID");
   pBLEScan = NimBLEDevice::getScan();
   pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
-  pBLEScan->setActiveScan(true);
+  pBLEScan->setActiveScan(false);  // Passive scan — less radio contention with WiFi promisc
 
   printQueue = xQueueCreate(MAX_UAVS, sizeof(id_data));
   


### PR DESCRIPTION
## Summary
- **skyspy: add Serial1 mesh output** — Sends compact drone/pilot location messages on pins D4/D5 for Heltec LoRa/Meshtastic forwarding, throttled to 5s intervals, 230-byte limit. No effect when mesh hardware is not connected.
- **skyspy: reduce BLE scan to prevent WiFi starvation** — 10s gap between BLE scans + passive scanning to avoid starving WiFi promiscuous mode and missing drone detections.
- **flockyou: NeoPixel LED support** — GPIO 4 NeoPixel with breathing animation, flash on new device detection.
- **flockyou: hardware GPS support** — Seeed L76K GNSS module integration.
- **flockyou: NeoPixel animation smoothness** — Improved breathing effect.

## Test plan
- [x] Sky Spy mesh output tested end-to-end: spoofer → detector → Serial1 → Heltec V3 → Meshtastic
- [x] USB serial JSON output unaffected (full rate, same format)
- [x] Firmware builds and flashes successfully (19.1% flash, 25.5% RAM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)