### PR TITLE
Fix GPS lock loss and LEDC buzzer initialization in Flock-You mode (Graphene OS)

### DIFF
--- a/GRAPHENEOS.md
+++ b/GRAPHENEOS.md
@@ -1,0 +1,167 @@
+# OUI-SPY Unified — GPS & Buzzer Fix Fork
+
+Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with fixes for **GPS lock loss during wardriving** and **LEDC buzzer initialization** in Flock-You mode (Mode 4).
+
+These fixes improve GPS reliability for all Android users and are especially relevant for anyone running **GrapheneOS**, where the combination of device-only GPS, sandboxed Google Play Services, and HTTP Geolocation API restrictions created a perfect storm for GPS failures.
+
+---
+
+## What's Fixed
+
+### GPS Auto-Recovery
+
+The original `watchPosition` call would silently stop delivering updates when the phone screen locked, Chrome backgrounded the tab, or the OS throttled location services. Once GPS went stale, new detections stopped getting tagged with coordinates — with no indication anything was wrong.
+
+**Changes to `src/raw/flockyou.cpp`:**
+
+- **Health monitor** — checks every 10 seconds whether GPS is still alive. If the last successful fix is older than 20 seconds, the watch is torn down and restarted automatically, before the ESP32's 30-second stale threshold expires
+- **Relaxed timing** — `maximumAge` increased from 5s to 15s, `timeout` from 15s to 30s. Device-only GPS (no network assist) needs more time to acquire satellites, especially on GrapheneOS
+- **Manual restart** — tapping the GPS card now always restarts the watch, even if GPS was previously working. The old code blocked re-initialization once a fix succeeded
+- **Send failure tracking** — counts consecutive failed `fetch` calls to `/api/gps`. After 3 failures, the indicator shows "SEND" (yellow) so you know the ESP32 isn't receiving coordinates
+- **Smarter UI state** — the stats poll no longer overrides JavaScript-managed GPS state. Previously it would reset the indicator to "TAP" (red) whenever the ESP32 reported no GPS source, even with an active watch
+- **Accuracy display** — shows accuracy in meters when >50m, so you can tell rough network fixes from proper GPS locks
+- **Fixed alert text** — double-escaped `\n` characters that displayed as literal `\n\n` in alert dialogs now render as actual line breaks
+
+### Buzzer LEDC Fix
+
+The boot crow caw sounded muffled and threw `LEDC is not initialized` errors because `tone()` was called before the ESP32's LEDC peripheral was ready.
+
+**Changes:**
+
+- Explicit LEDC channel 0 initialization in `setup()` before any audio plays
+- All `tone()`/`noTone()` calls replaced with direct `ledcSetup()`/`ledcWrite()` control, matching the approach used by Foxhunter and other modes
+- Crow caw now plays cleanly on boot with no error messages
+
+---
+
+## GrapheneOS Setup Guide
+
+GPS wardriving on Flock-You requires the browser Geolocation API over HTTP. GrapheneOS has additional privacy controls that need specific configuration. This guide was tested on a **Pixel 7a running GrapheneOS** with sandboxed Google Play Services.
+
+### Step 1: Enable Location Rerouting
+
+GrapheneOS sandboxes Google Play Services, which means Chrome's location requests go to Play Services — but Play Services doesn't have privileged location access like it does on stock Android. The requests silently fail.
+
+**Settings → Apps → Sandboxed Google Play → Google Play Services → Permissions → Reroute location requests to OS → Enable**
+
+This forwards location requests to GrapheneOS's own location provider (device-only GPS), which actually has hardware access.
+
+### Step 2: Grant Chrome Location Permission
+
+**Settings → Apps → Chrome → Permissions → Location → "Allow while using the app"**
+
+### Step 3: Set Chrome Flag for Insecure Origins
+
+The Geolocation API requires a secure context (HTTPS), but the ESP32 serves its dashboard over HTTP. Chrome has a flag to allow this for specific local IPs.
+
+1. Open Chrome
+2. Navigate to `chrome://flags`
+3. Search for **"Insecure origins treated as secure"**
+4. In the text field, enter: `http://192.168.4.1`
+5. Set the dropdown to **Enabled**
+6. Tap **Relaunch**
+
+### Step 4: Configure Chrome Site Permissions
+
+**Chrome → three dots → Settings → Site settings → Location:**
+
+- Set to **"Sites can ask for your location"**
+- Under "How to show requests," set to **"Expand all requests"** (prevents Chrome from silently collapsing the permission prompt for HTTP sites)
+
+### Step 5: Use Chrome — Not the Captive Portal
+
+This is the most common mistake. When you connect to the `flockyou` WiFi AP, Android shows a "Sign in to flockyou" captive portal popup. **This is a restricted WebView that does not support the Geolocation API at all.** GPS will always be denied in the captive portal browser.
+
+Instead:
+
+1. Connect to `flockyou` / `flockyou123`
+2. When the captive portal appears, tap the three dots → **"Use this network as is"**
+3. Open the **Chrome app** separately
+4. Navigate to `http://192.168.4.1`
+5. Tap the **GPS card** in the stats bar
+6. Chrome should prompt for location permission → tap **Allow**
+7. GPS indicator turns green with "OK" or accuracy in meters
+
+### Troubleshooting
+
+**GPS shows "DENIED" (red):**
+Chrome cached a previous denial. Go to Chrome → Settings → Site settings → Location, find `192.168.4.1` in the Blocked list, and remove it. If no Blocked list is visible, try opening an Incognito tab to `192.168.4.1` — Incognito starts with clean permissions. To reset all site permissions: Chrome → Settings → Privacy and security → Clear browsing data → Advanced → check only "Site settings" → Clear data.
+
+**GPS shows "..." (yellow) and never turns green:**
+GPS is acquiring. Device-only GPS (no network assist) can take 30–60 seconds for a cold fix, especially indoors. Move near a window or outside. The patched firmware allows up to 30 seconds before timing out and will auto-retry.
+
+**GPS shows "LOST" (yellow):**
+The health monitor detected that GPS went stale and is auto-restarting the watch. This is normal when resuming after screen lock or tab backgrounding. It should recover within a few seconds.
+
+**GPS shows "SEND" (yellow):**
+Chrome has a GPS fix but the `fetch` calls to the ESP32 are failing. Check that you're still connected to the `flockyou` WiFi AP.
+
+**`chrome://flags` setting disappeared after Chrome update:**
+GrapheneOS Chrome updates can reset flags. Re-enter `http://192.168.4.1` in the "Insecure origins treated as secure" field and relaunch.
+
+---
+
+## Building & Flashing
+
+Requires [PlatformIO](https://platformio.org/).
+
+```bash
+# Install PlatformIO
+pip3 install platformio
+
+# Build
+cd oui-spy-unified-blue
+pio run
+
+# Flash (plug in XIAO ESP32-S3 via USB-C data cable)
+pio run -t upload
+
+# Monitor serial output (optional)
+pio device monitor
+```
+
+---
+
+## Verifying GPS
+
+After flashing, connect your phone to the `flockyou` AP and open `http://192.168.4.1/api/stats` in Chrome. You should see:
+
+```json
+{
+  "gps_valid": true,
+  "gps_age": 1234,
+  "gps_src": "phone",
+  "gps_hw_detected": false
+}
+```
+
+- `gps_valid: true` — GPS is active
+- `gps_age` — milliseconds since last update (should be under 5000 if streaming)
+- `gps_src: "phone"` — coordinates coming from browser Geolocation API
+
+---
+
+## Hardware
+
+**Board:** Seeed Studio XIAO ESP32-S3
+
+| Pin | Function |
+|-----|----------|
+| GPIO 3 | Piezo buzzer |
+| GPIO 4 | NeoPixel LED |
+| GPIO 44/43 | Hardware GPS UART (optional Seeed L76K module) |
+
+---
+
+## Upstream
+
+All code changes are in `src/raw/flockyou.cpp`. See the original project for full documentation on all four firmware modes:
+
+**[colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue)**
+
+---
+
+## Credits
+
+- **colonelpanichacks** — original OUI-SPY Unified firmware
+- **wgreenberg** — Flock Safety BLE manufacturer ID research ([flock-you](https://github.com/wgreenberg/flock-you))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flock-You GPS & Buzzer Fix Fork
 
-Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with targeted fixes for **Flock-You mode (Mode 4)** — specifically GPS lock loss during wardriving, WiFi dropout on Android, and muffled buzzer audio on boot.
+Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with targeted fixes for **Flock-You mode (Mode 4)** — GPS lock loss during wardriving, WiFi dropout on Android, muffled buzzer audio, and added **RSSI distance estimation** with a configurable path-loss model.
 
 For full documentation on all four firmware modes (Detector, Foxhunter, Flock-You, Sky Spy), the boot selector, flashing with `flash.py`, hardware pinout, and the broader OUI-SPY ecosystem, see the **[original project README](https://github.com/colonelpanichacks/oui-spy-unified-blue)**.
 
@@ -8,55 +8,70 @@ This fork changes a single file: **`src/raw/flockyou.cpp`**
 
 ---
 
-## Why This Fork Exists
-
-Flock-You's GPS wardriving feature relies on the browser Geolocation API to tag surveillance device detections with coordinates. During real-world wardriving sessions, two problems caused most detections to lose their GPS tags:
-
-1. **WiFi dropout** — Android detected that the `flockyou` AP had no internet and silently switched back to mobile data, severing the GPS pipeline entirely
-2. **GPS watch dying** — Chrome's `watchPosition` would stop delivering updates when the screen locked or the tab backgrounded, with no recovery mechanism
-
-In testing, only 8 out of 47 detections (17%) were GPS-tagged. The remaining 39 lost their coordinates to these two issues.
-
-The buzzer also threw `LEDC is not initialized` errors on boot, producing muffled audio.
-
-These fixes improve Flock-You for all Android users and include a complete setup guide for **GrapheneOS**, where additional privacy controls make GPS configuration less obvious.
-
----
-
 ## What Changed
+
+### RSSI Distance Estimation
+
+Every detection now shows an estimated distance in meters based on the received signal strength, using the log-distance path-loss model:
+
+```
+distance = 10 ^ ((txPower - RSSI) / (10 × n))
+```
+
+Where `txPower` is the reference power at 1 meter (-59 dBm default for BLE) and `n` is the path-loss exponent that models signal attenuation in different environments.
+
+**Dashboard changes:**
+
+- Each detection card shows `~Xm` in yellow next to the RSSI value
+- The **Tools** tab has four environment preset buttons and a manual slider
+- Distance is included in JSON, CSV, and KML exports
+- Settings are saved to NVS and persist across reboots
+
+**Presets:**
+
+| Preset | Exponent (n) | Use case |
+|--------|-------------|----------|
+| **HIGHWAY** | 2.2 | Interstate/highway wardriving at 50-85 mph. Cameras are pole-mounted with clear line of sight. Minimal obstructions. |
+| **SUBURBAN** | 2.5 | Mixed residential/commercial roads. Some obstructions from buildings and vegetation. Good general-purpose default. |
+| **URBAN** | 3.0 | City streets with buildings, parked cars, and infrastructure creating multipath reflections. |
+| **DENSE** | 3.5 | Dense urban or areas with significant obstructions between you and the camera. |
+
+The slider allows manual tuning from 1.6 (pure open air) to 4.5 (heavy indoor attenuation) in 0.1 steps. If the default distance numbers feel consistently off, adjust the exponent until they match your observed reality — lower for open areas, higher for obstructed ones.
+
+**API:**
+
+- `GET /api/settings` — returns current path-loss exponent and TX power as JSON
+- `GET /api/settings?pl_n=2.2` — sets the exponent and saves to NVS
 
 ### WiFi Dropout Fix (Android Auto-Switch Prevention)
 
-Android checks specific URLs to determine if a WiFi network has internet access. When those checks fail, Android silently switches back to mobile data — killing the GPS pipeline between the phone and the ESP32. The `flockyou` AP's captive portal DNS already redirects all domains to `192.168.4.1`, but the web server was returning HTML redirects instead of the expected responses.
+Android detects that the `flockyou` AP has no internet and silently switches back to mobile data, severing the GPS pipeline. The fix adds proper handlers for connectivity check URLs from Android, GrapheneOS, Apple, Windows, and Firefox. Returning the expected responses tells the OS "this network has internet" and prevents the switch.
 
-The fix adds proper handlers for connectivity check URLs from all major platforms:
-
-- **Android / GrapheneOS** — responds to `/generate_204` and `/gen_204` with HTTP 204, which is the exact response Android expects to confirm internet connectivity
-- **Apple** — responds to `/hotspot-detect.html` and `/library/test/success.html` with the expected success page
-- **Windows** — responds to `/ncsi.txt` and `/connecttest.txt` with the expected test strings
-- **Firefox** — responds to `/success.txt` with the expected response
-
-The catch-all handler also pattern-matches any connectivity check URLs that might arrive via unexpected paths. This prevents the "Wi-Fi has no internet access" warning and stops Android from switching away from the `flockyou` AP during wardriving sessions.
+This eliminates the "Wi-Fi has no internet access" warning and the captive portal popup on most devices.
 
 ### GPS Auto-Recovery
 
-The browser Geolocation API's `watchPosition` call would silently stop delivering updates when Chrome backgrounded the tab, the phone screen locked, or the OS throttled location services. Once GPS went stale, the ESP32 had no way to know and new detections stopped getting tagged.
+The browser Geolocation API's `watchPosition` would silently stop delivering updates when Chrome backgrounded the tab, the phone screen locked, or the OS throttled location services.
 
-- **Health monitor** — checks every 10 seconds whether GPS is still alive. If the last fix is older than 20 seconds, the watch is torn down and restarted automatically before the ESP32's 30-second stale threshold expires
-- **Relaxed timing** — `maximumAge` increased from 5s to 15s, `timeout` from 15s to 30s, giving device-only GPS (no network assist) enough time to acquire satellites
-- **Manual restart** — tapping the GPS card now always restarts the watch, even if GPS was previously working
-- **Send failure tracking** — after 3 consecutive failed `fetch` calls to `/api/gps`, the indicator shows "SEND" (yellow) so you know the ESP32 isn't receiving coordinates
-- **Smarter UI state** — the stats poll no longer overrides JavaScript-managed GPS state
-- **Accuracy display** — shows accuracy in meters when >50m
-- **Fixed alert text** — double-escaped `\n` now renders as actual line breaks
+- **Health monitor** — checks every 10 seconds, auto-restarts the watch if GPS goes stale (20-second threshold)
+- **Relaxed timing** — `maximumAge` 15s, `timeout` 30s for device-only GPS (GrapheneOS)
+- **Manual restart** — tapping the GPS card always restarts, even after a previous success
+- **Send failure tracking** — shows "SEND" (yellow) after 3 consecutive failed fetch calls
+- **Accuracy display** — shows meters when >50m
 
 ### Buzzer LEDC Fix
 
-The boot crow caw sounded muffled and threw `LEDC is not initialized` errors because `tone()` was called before the ESP32's LEDC peripheral was ready.
+- Explicit LEDC channel 0 initialization in `setup()` before boot audio
+- All `tone()`/`noTone()` replaced with direct `ledcSetup()`/`ledcWrite()` control
+- Eliminates the `LEDC is not initialized` error
 
-- Explicit LEDC channel 0 initialization in `setup()` before any audio plays
-- All `tone()`/`noTone()` calls replaced with direct `ledcSetup()`/`ledcWrite()` control
-- Eliminates the `LEDC is not initialized` error and produces clean crow caw audio on boot
+### Security Audit Fixes
+
+- **XSS prevention** — BLE device names are HTML-escaped before rendering in the dashboard
+- **Expanded name sanitization** — strips `<`, `>`, `&`, and control characters in addition to `"` and `\`
+- **Null terminator safety** — Raven UUID copy guaranteed null-terminated
+- **Division by zero guard** — `fyCaw()` returns early if duration < 8ms
+- **Deprecated API fix** — ArduinoJson `containsKey` replaced with modern `is<T>()` API
 
 ---
 
@@ -122,9 +137,10 @@ With the WiFi dropout fix, you should no longer see the captive portal popup or 
 
 ### 6. Wardriving Tips
 
-- **Disable mobile data** as a belt-and-suspenders measure — even with the connectivity check fix, turning off mobile data guarantees Android can't switch away from the `flockyou` AP
-- **Keep Chrome in the foreground** — if you switch apps, the GPS watch may slow down or stop. The health monitor will restart it, but foreground delivery is more reliable
-- **Check GPS before driving** — confirm the indicator shows green "OK" before heading out. Open a second tab to `http://192.168.4.1/api/stats` and verify `gps_valid` is `true`
+- **Set the path-loss exponent before driving** — tap Tools, then HIGHWAY for interstate or URBAN for city streets
+- **Disable mobile data** as a belt-and-suspenders measure — even with the connectivity check fix, this guarantees Android stays on the `flockyou` AP
+- **Keep Chrome in the foreground** — the GPS health monitor auto-restarts on background, but foreground is more reliable
+- **Check GPS before driving** — confirm green "OK" on the GPS card before heading out
 
 ---
 
@@ -137,19 +153,22 @@ Chrome cached a previous denial. Open an **Incognito tab** to `192.168.4.1` to t
 Device-only GPS can take 30–60 seconds for a cold fix, especially indoors. Move near a window or outside. The firmware allows up to 30 seconds per attempt and retries automatically.
 
 **Still getting "Wi-Fi has no internet access":**
-This should be resolved by the connectivity check fix. If it persists, disable mobile data before connecting to `flockyou` — Android can't switch to what isn't available.
+This should be resolved by the connectivity check fix. If it persists, disable mobile data before connecting to `flockyou`.
+
+**Distance estimates seem wrong:**
+Adjust the path-loss exponent in Tools. If distances are consistently too short, increase n. If too long, decrease n. The model is an approximation — BLE signal strength varies with antenna orientation, obstructions, and multipath reflections.
 
 **`chrome://flags` setting disappeared:**
 GrapheneOS Chrome updates can reset flags. Re-enter `http://192.168.4.1` and relaunch.
 
 **Verifying GPS without a Flock camera nearby:**
-Open a second Chrome tab to `http://192.168.4.1/api/stats` — if `gps_valid` is `true` and `gps_age` is under 5000, coordinates are streaming to the ESP32 and will tag any future detections.
+Open a second Chrome tab to `http://192.168.4.1/api/stats` — if `gps_valid` is `true` and `gps_age` is under 5000, GPS is streaming.
 
 **Serial monitor shows `LEDC is not initialized`:**
-You're running the original firmware, not the patched version. Rebuild and reflash with `pio run -t upload`.
+You're running the original firmware. Rebuild and reflash with `pio run -t upload`.
 
 **PlatformIO flashes the wrong device:**
-If `pio run -t upload` picks the wrong USB device, find the ESP32's port with `ls /dev/cu.usb*` and specify it: `pio run -t upload --upload-port /dev/cu.usbmodem1101`
+Find the ESP32's port with `ls /dev/cu.usb*` and specify it: `pio run -t upload --upload-port /dev/cu.usbmodem1101`
 
 ---
 
@@ -170,12 +189,13 @@ Monitor serial output (optional):
 pio device monitor
 ```
 
-A clean boot should show no LEDC errors:
+A clean boot shows:
 
 ```
 ========================================
   FLOCK-YOU Surveillance Detector
   Buzzer: ON
+  Path-loss n: 2.5
   GPS: auto-detect (L76K on D6/D7)
 ========================================
 [FLOCK-YOU] BLE scanning ACTIVE

--- a/README.md
+++ b/README.md
@@ -1,167 +1,192 @@
-# OUI-SPY Unified — GPS & Buzzer Fix Fork
+# Flock-You GPS & Buzzer Fix Fork
 
-Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with fixes for **GPS lock loss during wardriving** and **LEDC buzzer initialization** in Flock-You mode (Mode 4).
+Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with targeted fixes for **Flock-You mode (Mode 4)** — specifically GPS lock loss during wardriving, WiFi dropout on Android, and muffled buzzer audio on boot.
 
-These fixes improve GPS reliability for all Android users and are especially relevant for anyone running **GrapheneOS**, where the combination of device-only GPS, sandboxed Google Play Services, and HTTP Geolocation API restrictions created a perfect storm for GPS failures.
+For full documentation on all four firmware modes (Detector, Foxhunter, Flock-You, Sky Spy), the boot selector, flashing with `flash.py`, hardware pinout, and the broader OUI-SPY ecosystem, see the **[original project README](https://github.com/colonelpanichacks/oui-spy-unified-blue)**.
+
+This fork changes a single file: **`src/raw/flockyou.cpp`**
 
 ---
 
-## What's Fixed
+## Why This Fork Exists
+
+Flock-You's GPS wardriving feature relies on the browser Geolocation API to tag surveillance device detections with coordinates. During real-world wardriving sessions, two problems caused most detections to lose their GPS tags:
+
+1. **WiFi dropout** — Android detected that the `flockyou` AP had no internet and silently switched back to mobile data, severing the GPS pipeline entirely
+2. **GPS watch dying** — Chrome's `watchPosition` would stop delivering updates when the screen locked or the tab backgrounded, with no recovery mechanism
+
+In testing, only 8 out of 47 detections (17%) were GPS-tagged. The remaining 39 lost their coordinates to these two issues.
+
+The buzzer also threw `LEDC is not initialized` errors on boot, producing muffled audio.
+
+These fixes improve Flock-You for all Android users and include a complete setup guide for **GrapheneOS**, where additional privacy controls make GPS configuration less obvious.
+
+---
+
+## What Changed
+
+### WiFi Dropout Fix (Android Auto-Switch Prevention)
+
+Android checks specific URLs to determine if a WiFi network has internet access. When those checks fail, Android silently switches back to mobile data — killing the GPS pipeline between the phone and the ESP32. The `flockyou` AP's captive portal DNS already redirects all domains to `192.168.4.1`, but the web server was returning HTML redirects instead of the expected responses.
+
+The fix adds proper handlers for connectivity check URLs from all major platforms:
+
+- **Android / GrapheneOS** — responds to `/generate_204` and `/gen_204` with HTTP 204, which is the exact response Android expects to confirm internet connectivity
+- **Apple** — responds to `/hotspot-detect.html` and `/library/test/success.html` with the expected success page
+- **Windows** — responds to `/ncsi.txt` and `/connecttest.txt` with the expected test strings
+- **Firefox** — responds to `/success.txt` with the expected response
+
+The catch-all handler also pattern-matches any connectivity check URLs that might arrive via unexpected paths. This prevents the "Wi-Fi has no internet access" warning and stops Android from switching away from the `flockyou` AP during wardriving sessions.
 
 ### GPS Auto-Recovery
 
-The original `watchPosition` call would silently stop delivering updates when the phone screen locked, Chrome backgrounded the tab, or the OS throttled location services. Once GPS went stale, new detections stopped getting tagged with coordinates — with no indication anything was wrong.
+The browser Geolocation API's `watchPosition` call would silently stop delivering updates when Chrome backgrounded the tab, the phone screen locked, or the OS throttled location services. Once GPS went stale, the ESP32 had no way to know and new detections stopped getting tagged.
 
-**Changes to `src/raw/flockyou.cpp`:**
-
-- **Health monitor** — checks every 10 seconds whether GPS is still alive. If the last successful fix is older than 20 seconds, the watch is torn down and restarted automatically, before the ESP32's 30-second stale threshold expires
-- **Relaxed timing** — `maximumAge` increased from 5s to 15s, `timeout` from 15s to 30s. Device-only GPS (no network assist) needs more time to acquire satellites, especially on GrapheneOS
-- **Manual restart** — tapping the GPS card now always restarts the watch, even if GPS was previously working. The old code blocked re-initialization once a fix succeeded
-- **Send failure tracking** — counts consecutive failed `fetch` calls to `/api/gps`. After 3 failures, the indicator shows "SEND" (yellow) so you know the ESP32 isn't receiving coordinates
-- **Smarter UI state** — the stats poll no longer overrides JavaScript-managed GPS state. Previously it would reset the indicator to "TAP" (red) whenever the ESP32 reported no GPS source, even with an active watch
-- **Accuracy display** — shows accuracy in meters when >50m, so you can tell rough network fixes from proper GPS locks
-- **Fixed alert text** — double-escaped `\n` characters that displayed as literal `\n\n` in alert dialogs now render as actual line breaks
+- **Health monitor** — checks every 10 seconds whether GPS is still alive. If the last fix is older than 20 seconds, the watch is torn down and restarted automatically before the ESP32's 30-second stale threshold expires
+- **Relaxed timing** — `maximumAge` increased from 5s to 15s, `timeout` from 15s to 30s, giving device-only GPS (no network assist) enough time to acquire satellites
+- **Manual restart** — tapping the GPS card now always restarts the watch, even if GPS was previously working
+- **Send failure tracking** — after 3 consecutive failed `fetch` calls to `/api/gps`, the indicator shows "SEND" (yellow) so you know the ESP32 isn't receiving coordinates
+- **Smarter UI state** — the stats poll no longer overrides JavaScript-managed GPS state
+- **Accuracy display** — shows accuracy in meters when >50m
+- **Fixed alert text** — double-escaped `\n` now renders as actual line breaks
 
 ### Buzzer LEDC Fix
 
 The boot crow caw sounded muffled and threw `LEDC is not initialized` errors because `tone()` was called before the ESP32's LEDC peripheral was ready.
 
-**Changes:**
-
 - Explicit LEDC channel 0 initialization in `setup()` before any audio plays
-- All `tone()`/`noTone()` calls replaced with direct `ledcSetup()`/`ledcWrite()` control, matching the approach used by Foxhunter and other modes
-- Crow caw now plays cleanly on boot with no error messages
+- All `tone()`/`noTone()` calls replaced with direct `ledcSetup()`/`ledcWrite()` control
+- Eliminates the `LEDC is not initialized` error and produces clean crow caw audio on boot
+
+---
+
+## GPS Indicator States
+
+| Indicator | Color | Meaning |
+|-----------|-------|---------|
+| **TAP** | Red | GPS not started — tap the card to begin |
+| **...** | Yellow | Acquiring GPS fix |
+| **OK** | Green | GPS active, accuracy <50m |
+| **~25m** | Green | GPS active, showing accuracy in meters |
+| **WAIT** | Yellow | Timeout, retrying automatically |
+| **LOST** | Yellow | Health monitor detected stale GPS, restarting watch |
+| **SEND** | Yellow | GPS fix acquired but fetch to ESP32 failing |
+| **DENIED** | Red | Browser denied location permission — see setup below |
+| **N/A** | Red | Geolocation API not available in this browser |
 
 ---
 
 ## GrapheneOS Setup Guide
 
-GPS wardriving on Flock-You requires the browser Geolocation API over HTTP. GrapheneOS has additional privacy controls that need specific configuration. This guide was tested on a **Pixel 7a running GrapheneOS** with sandboxed Google Play Services.
+GPS wardriving in Flock-You requires the browser Geolocation API over HTTP. GrapheneOS has additional privacy controls that need specific configuration. Tested on a **Pixel 7a running GrapheneOS** with sandboxed Google Play Services.
 
-### Step 1: Enable Location Rerouting
+### 1. Enable Location Rerouting
 
-GrapheneOS sandboxes Google Play Services, which means Chrome's location requests go to Play Services — but Play Services doesn't have privileged location access like it does on stock Android. The requests silently fail.
+Chrome's location requests go through Google Play Services, but on GrapheneOS, sandboxed Play Services doesn't have privileged location access. Requests silently fail unless rerouted.
 
-**Settings → Apps → Sandboxed Google Play → Google Play Services → Permissions → Reroute location requests to OS → Enable**
+**Settings → Apps → Sandboxed Google Play → Google Play Services → Reroute location requests to OS → Enable**
 
-This forwards location requests to GrapheneOS's own location provider (device-only GPS), which actually has hardware access.
-
-### Step 2: Grant Chrome Location Permission
+### 2. Grant Chrome Location Permission
 
 **Settings → Apps → Chrome → Permissions → Location → "Allow while using the app"**
 
-### Step 3: Set Chrome Flag for Insecure Origins
+### 3. Chrome Flag for Insecure Origins
 
-The Geolocation API requires a secure context (HTTPS), but the ESP32 serves its dashboard over HTTP. Chrome has a flag to allow this for specific local IPs.
+The Geolocation API requires HTTPS, but the ESP32 serves over HTTP. Chrome has a flag to allow specific local IPs.
 
-1. Open Chrome
-2. Navigate to `chrome://flags`
-3. Search for **"Insecure origins treated as secure"**
-4. In the text field, enter: `http://192.168.4.1`
-5. Set the dropdown to **Enabled**
-6. Tap **Relaunch**
+1. Open Chrome → navigate to `chrome://flags`
+2. Search **"Insecure origins treated as secure"**
+3. Enter `http://192.168.4.1` in the text field
+4. Set dropdown to **Enabled**
+5. Tap **Relaunch**
 
-### Step 4: Configure Chrome Site Permissions
+### 4. Chrome Site Permissions
 
 **Chrome → three dots → Settings → Site settings → Location:**
 
 - Set to **"Sites can ask for your location"**
-- Under "How to show requests," set to **"Expand all requests"** (prevents Chrome from silently collapsing the permission prompt for HTTP sites)
+- Under "How to show requests," set to **"Expand all requests"** — this prevents Chrome from silently suppressing the permission prompt for HTTP sites
 
-### Step 5: Use Chrome — Not the Captive Portal
+### 5. Use Chrome — Not the Captive Portal
 
-This is the most common mistake. When you connect to the `flockyou` WiFi AP, Android shows a "Sign in to flockyou" captive portal popup. **This is a restricted WebView that does not support the Geolocation API at all.** GPS will always be denied in the captive portal browser.
+When you connect to the `flockyou` WiFi AP, Android may show a "Sign in to flockyou" captive portal popup. **This is a restricted WebView that does not support the Geolocation API.** GPS will always be denied in the captive portal.
 
-Instead:
+With the WiFi dropout fix, you should no longer see the captive portal popup or the "Wi-Fi has no internet access" warning. If it does appear:
 
-1. Connect to `flockyou` / `flockyou123`
-2. When the captive portal appears, tap the three dots → **"Use this network as is"**
-3. Open the **Chrome app** separately
-4. Navigate to `http://192.168.4.1`
-5. Tap the **GPS card** in the stats bar
-6. Chrome should prompt for location permission → tap **Allow**
-7. GPS indicator turns green with "OK" or accuracy in meters
+1. Tap the three dots → **"Use this network as is"**
+2. Open the **Chrome app** separately
+3. Navigate to `http://192.168.4.1`
+4. Tap the **GPS card** in the stats bar
+5. Chrome prompts for location permission → tap **Allow**
+6. GPS indicator turns green
 
-### Troubleshooting
+### 6. Wardriving Tips
 
-**GPS shows "DENIED" (red):**
-Chrome cached a previous denial. Go to Chrome → Settings → Site settings → Location, find `192.168.4.1` in the Blocked list, and remove it. If no Blocked list is visible, try opening an Incognito tab to `192.168.4.1` — Incognito starts with clean permissions. To reset all site permissions: Chrome → Settings → Privacy and security → Clear browsing data → Advanced → check only "Site settings" → Clear data.
-
-**GPS shows "..." (yellow) and never turns green:**
-GPS is acquiring. Device-only GPS (no network assist) can take 30–60 seconds for a cold fix, especially indoors. Move near a window or outside. The patched firmware allows up to 30 seconds before timing out and will auto-retry.
-
-**GPS shows "LOST" (yellow):**
-The health monitor detected that GPS went stale and is auto-restarting the watch. This is normal when resuming after screen lock or tab backgrounding. It should recover within a few seconds.
-
-**GPS shows "SEND" (yellow):**
-Chrome has a GPS fix but the `fetch` calls to the ESP32 are failing. Check that you're still connected to the `flockyou` WiFi AP.
-
-**`chrome://flags` setting disappeared after Chrome update:**
-GrapheneOS Chrome updates can reset flags. Re-enter `http://192.168.4.1` in the "Insecure origins treated as secure" field and relaunch.
+- **Disable mobile data** as a belt-and-suspenders measure — even with the connectivity check fix, turning off mobile data guarantees Android can't switch away from the `flockyou` AP
+- **Keep Chrome in the foreground** — if you switch apps, the GPS watch may slow down or stop. The health monitor will restart it, but foreground delivery is more reliable
+- **Check GPS before driving** — confirm the indicator shows green "OK" before heading out. Open a second tab to `http://192.168.4.1/api/stats` and verify `gps_valid` is `true`
 
 ---
 
-## Building & Flashing
+## Troubleshooting
 
-Requires [PlatformIO](https://platformio.org/).
+**GPS shows "DENIED" after following all steps:**
+Chrome cached a previous denial. Open an **Incognito tab** to `192.168.4.1` to test with clean permissions. To fix permanently: Chrome → Settings → Privacy and security → Clear browsing data → Advanced → check only "Site settings" → Clear data.
+
+**GPS shows "..." and never turns green:**
+Device-only GPS can take 30–60 seconds for a cold fix, especially indoors. Move near a window or outside. The firmware allows up to 30 seconds per attempt and retries automatically.
+
+**Still getting "Wi-Fi has no internet access":**
+This should be resolved by the connectivity check fix. If it persists, disable mobile data before connecting to `flockyou` — Android can't switch to what isn't available.
+
+**`chrome://flags` setting disappeared:**
+GrapheneOS Chrome updates can reset flags. Re-enter `http://192.168.4.1` and relaunch.
+
+**Verifying GPS without a Flock camera nearby:**
+Open a second Chrome tab to `http://192.168.4.1/api/stats` — if `gps_valid` is `true` and `gps_age` is under 5000, coordinates are streaming to the ESP32 and will tag any future detections.
+
+**Serial monitor shows `LEDC is not initialized`:**
+You're running the original firmware, not the patched version. Rebuild and reflash with `pio run -t upload`.
+
+**PlatformIO flashes the wrong device:**
+If `pio run -t upload` picks the wrong USB device, find the ESP32's port with `ls /dev/cu.usb*` and specify it: `pio run -t upload --upload-port /dev/cu.usbmodem1101`
+
+---
+
+## Building from Source
+
+Only the Flock-You source file was modified. Build and flash with [PlatformIO](https://platformio.org/):
 
 ```bash
-# Install PlatformIO
 pip3 install platformio
-
-# Build
 cd oui-spy-unified-blue
 pio run
-
-# Flash (plug in XIAO ESP32-S3 via USB-C data cable)
 pio run -t upload
+```
 
-# Monitor serial output (optional)
+Monitor serial output (optional):
+
+```bash
 pio device monitor
 ```
 
----
+A clean boot should show no LEDC errors:
 
-## Verifying GPS
-
-After flashing, connect your phone to the `flockyou` AP and open `http://192.168.4.1/api/stats` in Chrome. You should see:
-
-```json
-{
-  "gps_valid": true,
-  "gps_age": 1234,
-  "gps_src": "phone",
-  "gps_hw_detected": false
-}
 ```
-
-- `gps_valid: true` — GPS is active
-- `gps_age` — milliseconds since last update (should be under 5000 if streaming)
-- `gps_src: "phone"` — coordinates coming from browser Geolocation API
-
----
-
-## Hardware
-
-**Board:** Seeed Studio XIAO ESP32-S3
-
-| Pin | Function |
-|-----|----------|
-| GPIO 3 | Piezo buzzer |
-| GPIO 4 | NeoPixel LED |
-| GPIO 44/43 | Hardware GPS UART (optional Seeed L76K module) |
-
----
-
-## Upstream
-
-All code changes are in `src/raw/flockyou.cpp`. See the original project for full documentation on all four firmware modes:
-
-**[colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue)**
+========================================
+  FLOCK-YOU Surveillance Detector
+  Buzzer: ON
+  GPS: auto-detect (L76K on D6/D7)
+========================================
+[FLOCK-YOU] BLE scanning ACTIVE
+[FLOCK-YOU] *caw caw caw*
+[FLOCK-YOU] AP: flockyou / flockyou123
+[FLOCK-YOU] Ready - no WiFi connection needed, BLE + AP only
+```
 
 ---
 
 ## Credits
 
-- **colonelpanichacks** — original OUI-SPY Unified firmware
-- **wgreenberg** — Flock Safety BLE manufacturer ID research ([flock-you](https://github.com/wgreenberg/flock-you))
+- **[colonelpanichacks](https://github.com/colonelpanichacks)** — OUI-SPY Unified firmware and the Flock-You detection engine
+- **[wgreenberg](https://github.com/wgreenberg)** — Flock Safety BLE manufacturer ID research ([flock-you](https://github.com/wgreenberg/flock-you))

--- a/README.md
+++ b/README.md
@@ -1,102 +1,143 @@
-# OUI SPY
+# OUI-SPY Unified — GPS & Buzzer Fix Fork
 
-Multi-mode surveillance detection and BLE intelligence firmware for the **Seeed Studio XIAO ESP32-S3**.
+Fork of [colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue) with fixes for **GPS lock loss during wardriving** and **LEDC buzzer initialization** in Flock-You mode (Mode 4).
 
-One device. Four firmware modes. Select from a boot menu, reboot, and go.
-
----
-
-## Quick Connect
-
-On first boot, connect to the selector AP to pick a firmware mode:
-
-> **SSID:** `oui-spy` | **Password:** `ouispy123` | **Dashboard:** `192.168.4.1`
+These fixes improve GPS reliability for all Android users and are especially relevant for anyone running **GrapheneOS**, where the combination of device-only GPS, sandboxed Google Play Services, and HTTP Geolocation API restrictions created a perfect storm for GPS failures.
 
 ---
 
-## Modes
+## What's Fixed
 
-### Mode 1: Detector
+### GPS Auto-Recovery
 
-BLE alert tool that continuously scans for specific target devices by OUI prefix, MAC address, and device name patterns. When a match is found, the device triggers audible and visual alerts. Configurable target lists via web interface.
+The original `watchPosition` call would silently stop delivering updates when the phone screen locked, Chrome backgrounded the tab, or the OS throttled location services. Once GPS went stale, new detections stopped getting tagged with coordinates — with no indication anything was wrong.
 
-- AP: `snoopuntothem`
-- Scans BLE advertisements against user-configured MAC/OUI watchlists
-- NeoPixel + buzzer feedback on detection
-- Web dashboard for managing targets and viewing scan results
+**Changes to `src/raw/flockyou.cpp`:**
 
-### Mode 2: Foxhunter
+- **Health monitor** — checks every 10 seconds whether GPS is still alive. If the last successful fix is older than 20 seconds, the watch is torn down and restarted automatically, before the ESP32's 30-second stale threshold expires
+- **Relaxed timing** — `maximumAge` increased from 5s to 15s, `timeout` from 15s to 30s. Device-only GPS (no network assist) needs more time to acquire satellites, especially on GrapheneOS
+- **Manual restart** — tapping the GPS card now always restarts the watch, even if GPS was previously working. The old code blocked re-initialization once a fix succeeded
+- **Send failure tracking** — counts consecutive failed `fetch` calls to `/api/gps`. After 3 failures, the indicator shows "SEND" (yellow) so you know the ESP32 isn't receiving coordinates
+- **Smarter UI state** — the stats poll no longer overrides JavaScript-managed GPS state. Previously it would reset the indicator to "TAP" (red) whenever the ESP32 reported no GPS source, even with an active watch
+- **Accuracy display** — shows accuracy in meters when >50m, so you can tell rough network fixes from proper GPS locks
+- **Fixed alert text** — double-escaped `\n` characters that displayed as literal `\n\n` in alert dialogs now render as actual line breaks
 
-RSSI-based proximity tracker for hunting down a specific BLE device. Lock onto a target MAC address, then follow the signal strength. The buzzer cadence increases as you get closer — like a Geiger counter for Bluetooth.
+### Buzzer LEDC Fix
 
-- AP: `foxhunter`
-- Select target from live BLE scan or enter MAC manually
-- Audio feedback rate scales inversely with distance
-- Web interface for target selection and RSSI monitoring
+The boot crow caw sounded muffled and threw `LEDC is not initialized` errors because `tone()` was called before the ESP32's LEDC peripheral was ready.
 
-### Mode 3: Flock-You
+**Changes:**
 
-Detects Flock Safety surveillance cameras, Raven gunshot detectors, and related monitoring hardware using BLE-only heuristics. All detections are stored in memory and can be exported as JSON or CSV for later analysis.
-
-**Detection methods:**
-
-- **MAC prefix matching** — 20 known Flock Safety OUI prefixes (FS Ext Battery, Flock WiFi modules)
-- **BLE device name patterns** — case-insensitive substring matching for `FS Ext Battery`, `Penguin`, `Flock`, `Pigvision`
-- **BLE manufacturer company ID** — `0x09C8` (XUNTONG), associated with Flock Safety hardware. Catches devices even when no name is broadcast. *Sourced from [wgreenberg/flock-you](https://github.com/wgreenberg/flock-you).*
-- **Raven service UUID matching** — identifies Raven gunshot detection units by their BLE GATT service UUIDs (device info, GPS, power, network, upload, error, legacy health/location services)
-- **Raven firmware version estimation** — determines approximate firmware version (1.1.x / 1.2.x / 1.3.x) based on which service UUIDs are advertised
-
-**Features:**
-
-- AP: `flockyou` / password: `flockyou123`
-- Web dashboard at `192.168.4.1` with live detection feed, full pattern database browser, and export tools
-- **GPS wardriving** — uses your phone's GPS via the browser Geolocation API to tag every detection with coordinates
-- JSON and CSV export of all detections (MAC, name, RSSI, detection method, timestamps, count, Raven status, firmware version, GPS coordinates)
-- JSON-formatted serial output (with GPS) for live ingestion by the companion Flask dashboard
-- Thread-safe detection storage (up to 200 unique devices) with FreeRTOS mutex
-
-**Enabling GPS (Android Chrome):**
-
-The phone's GPS is used to geotag detections. Because the dashboard is served over HTTP, Chrome requires a one-time flag change to allow location access:
-
-1. Open a new Chrome tab and go to `chrome://flags`
-2. Search for **"Insecure origins treated as secure"**
-3. Add `http://192.168.4.1` to the text field
-4. Set the flag to **Enabled**
-5. Tap **Relaunch**
-
-After relaunching, connect to the `flockyou` AP, open `192.168.4.1`, and tap the **GPS** card in the stats bar to grant location permission. Detections will be tagged with coordinates automatically.
-
-> **Note:** iOS Safari does not support Geolocation over HTTP. GPS wardriving requires Android with Chrome.
-
-### Mode 4: Sky Spy
-
-Passive drone detection via FAA Remote ID (Open Drone ID) WiFi beacon monitoring. Listens in promiscuous mode for ASTM F3411 compliant broadcasts and extracts drone telemetry.
-
-- Captures drone serial numbers, operator/UAV IDs
-- Tracks location (lat/lon), altitude, ground speed, heading
-- Parses all ODID message types: Basic ID, Location, Authentication, Self-ID, System, Operator ID
-- Real-time logging of all detected drones
-- Dedicated FreeRTOS buzzer task for non-blocking audio alerts
+- Explicit LEDC channel 0 initialization in `setup()` before any audio plays
+- All `tone()`/`noTone()` calls replaced with direct `ledcSetup()`/`ledcWrite()` control, matching the approach used by Foxhunter and other modes
+- Crow caw now plays cleanly on boot with no error messages
 
 ---
 
-## WiFi Access Points
+## GrapheneOS Setup Guide
 
-Each mode creates its own AP. When switching modes, **your phone/laptop will auto-reconnect to the last saved network**, which may be the wrong mode's AP. To avoid confusion:
+GPS wardriving on Flock-You requires the browser Geolocation API over HTTP. GrapheneOS has additional privacy controls that need specific configuration. This guide was tested on a **Pixel 7a running GrapheneOS** with sandboxed Google Play Services.
 
-- **Forget the previous mode's network** before switching, or
-- **Disable auto-connect/auto-reconnect** for all OUI-SPY networks in your WiFi settings
+### Step 1: Enable Location Rerouting
 
-| Mode | SSID | Password | Dashboard | Notes |
-|------|------|----------|-----------|-------|
-| **Boot Selector** | `oui-spy` | `ouispy123` | `192.168.4.1` | Configurable from selector UI, saved to NVS |
-| **Detector** | `snoopuntothem` | `astheysnoopuntous` | `192.168.4.1` | Configurable from web dashboard, saved to NVS |
-| **Foxhunter** | `foxhunter` | `foxhunter` | `192.168.4.1` | Fixed credentials |
-| **Flock-You** | `flockyou` | `flockyou123` | `192.168.4.1` | Fixed credentials |
-| **Sky Spy** | *none* | — | — | No AP — passive scanner, serial JSON output only |
+GrapheneOS sandboxes Google Play Services, which means Chrome's location requests go to Play Services — but Play Services doesn't have privileged location access like it does on stock Android. The requests silently fail.
 
-> **Tip:** If you can't reach the dashboard after a mode switch, check which WiFi network you're connected to. Your device may have auto-joined a previously saved OUI-SPY AP from a different mode.
+**Settings → Apps → Sandboxed Google Play → Google Play Services → Permissions → Reroute location requests to OS → Enable**
+
+This forwards location requests to GrapheneOS's own location provider (device-only GPS), which actually has hardware access.
+
+### Step 2: Grant Chrome Location Permission
+
+**Settings → Apps → Chrome → Permissions → Location → "Allow while using the app"**
+
+### Step 3: Set Chrome Flag for Insecure Origins
+
+The Geolocation API requires a secure context (HTTPS), but the ESP32 serves its dashboard over HTTP. Chrome has a flag to allow this for specific local IPs.
+
+1. Open Chrome
+2. Navigate to `chrome://flags`
+3. Search for **"Insecure origins treated as secure"**
+4. In the text field, enter: `http://192.168.4.1`
+5. Set the dropdown to **Enabled**
+6. Tap **Relaunch**
+
+### Step 4: Configure Chrome Site Permissions
+
+**Chrome → three dots → Settings → Site settings → Location:**
+
+- Set to **"Sites can ask for your location"**
+- Under "How to show requests," set to **"Expand all requests"** (prevents Chrome from silently collapsing the permission prompt for HTTP sites)
+
+### Step 5: Use Chrome — Not the Captive Portal
+
+This is the most common mistake. When you connect to the `flockyou` WiFi AP, Android shows a "Sign in to flockyou" captive portal popup. **This is a restricted WebView that does not support the Geolocation API at all.** GPS will always be denied in the captive portal browser.
+
+Instead:
+
+1. Connect to `flockyou` / `flockyou123`
+2. When the captive portal appears, tap the three dots → **"Use this network as is"**
+3. Open the **Chrome app** separately
+4. Navigate to `http://192.168.4.1`
+5. Tap the **GPS card** in the stats bar
+6. Chrome should prompt for location permission → tap **Allow**
+7. GPS indicator turns green with "OK" or accuracy in meters
+
+### Troubleshooting
+
+**GPS shows "DENIED" (red):**
+Chrome cached a previous denial. Go to Chrome → Settings → Site settings → Location, find `192.168.4.1` in the Blocked list, and remove it. If no Blocked list is visible, try opening an Incognito tab to `192.168.4.1` — Incognito starts with clean permissions. To reset all site permissions: Chrome → Settings → Privacy and security → Clear browsing data → Advanced → check only "Site settings" → Clear data.
+
+**GPS shows "..." (yellow) and never turns green:**
+GPS is acquiring. Device-only GPS (no network assist) can take 30–60 seconds for a cold fix, especially indoors. Move near a window or outside. The patched firmware allows up to 30 seconds before timing out and will auto-retry.
+
+**GPS shows "LOST" (yellow):**
+The health monitor detected that GPS went stale and is auto-restarting the watch. This is normal when resuming after screen lock or tab backgrounding. It should recover within a few seconds.
+
+**GPS shows "SEND" (yellow):**
+Chrome has a GPS fix but the `fetch` calls to the ESP32 are failing. Check that you're still connected to the `flockyou` WiFi AP.
+
+**`chrome://flags` setting disappeared after Chrome update:**
+GrapheneOS Chrome updates can reset flags. Re-enter `http://192.168.4.1` in the "Insecure origins treated as secure" field and relaunch.
+
+---
+
+## Building & Flashing
+
+Requires [PlatformIO](https://platformio.org/).
+
+```bash
+# Install PlatformIO
+pip3 install platformio
+
+# Build
+cd oui-spy-unified-blue
+pio run
+
+# Flash (plug in XIAO ESP32-S3 via USB-C data cable)
+pio run -t upload
+
+# Monitor serial output (optional)
+pio device monitor
+```
+
+---
+
+## Verifying GPS
+
+After flashing, connect your phone to the `flockyou` AP and open `http://192.168.4.1/api/stats` in Chrome. You should see:
+
+```json
+{
+  "gps_valid": true,
+  "gps_age": 1234,
+  "gps_src": "phone",
+  "gps_hw_detected": false
+}
+```
+
+- `gps_valid: true` — GPS is active
+- `gps_age` — milliseconds since last update (should be under 5000 if streaming)
+- `gps_src: "phone"` — coordinates coming from browser Geolocation API
 
 ---
 
@@ -107,197 +148,20 @@ Each mode creates its own AP. When switching modes, **your phone/laptop will aut
 | Pin | Function |
 |-----|----------|
 | GPIO 3 | Piezo buzzer |
-| GPIO 21 | NeoPixel LED |
-| GPIO 0 | BOOT button (hold 2s to return to mode selector) |
+| GPIO 4 | NeoPixel LED |
+| GPIO 44/43 | Hardware GPS UART (optional Seeed L76K module) |
 
 ---
 
-## Boot Selector
+## Upstream
 
-On power-up, the device starts a WiFi access point (`oui-spy` / `ouispy123` by default) and serves a firmware selector at `192.168.4.1`. Pick a mode, the device stores the selection in NVS, and reboots into it.
+All code changes are in `src/raw/flockyou.cpp`. See the original project for full documentation on all four firmware modes:
 
-- **Return to menu:** Hold the BOOT button for 2 seconds at any time
-- **AP credentials:** Configurable SSID and password from the selector page, stored in NVS
-- **Buzzer toggle:** Enable/disable the boot buzzer globally from the selector menu
-- **MAC randomization:** Device MAC is randomized on every boot
-- **Boot sounds:** Each mode plays its own distinct tone sequence on startup — modulated sweeps, retro melodies, and other piezo-buzzer tributes to let you know which firmware you're in before the screen is even up
+**[colonelpanichacks/oui-spy-unified-blue](https://github.com/colonelpanichacks/oui-spy-unified-blue)**
 
 ---
 
-## Flashing
+## Credits
 
-Everything you need to flash a board is included in the repo. No PlatformIO or build tools required -- just Python and a USB cable.
-
-### What You Need
-
-- **Python 3.8 or newer** -- [download here](https://www.python.org/downloads/) if you don't have it
-  - Windows: check **"Add Python to PATH"** during install
-  - macOS: `brew install python3` or use the installer from python.org
-  - Linux: `sudo apt install python3 python3-pip`
-- **USB-C data cable** -- must be a data cable, not a charge-only cable
-- **USB drivers** (if your OS doesn't auto-detect the board):
-  - CH340/CH341: https://www.wch-ic.com/downloads/CH341SER_ZIP.html
-  - CP210x: https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers
-
-### Step 1: Install Dependencies
-
-```bash
-pip install -r requirements.txt
-```
-
-Or manually:
-
-```bash
-pip install esptool pyserial
-```
-
-> **Note:** On some systems you may need to use `pip3` instead of `pip`, and `python3` instead of `python`.
-
-### Step 2: Flash a Single Board
-
-1. Plug in your XIAO ESP32-S3 via USB-C
-2. Run:
-
-```bash
-python3 flash.py
-```
-
-3. The script auto-detects your board and the firmware
-4. Type `y` and press Enter to confirm
-5. Wait for "Done!" -- the board reboots automatically and plays a boot melody
-
-### Step 3: Verify It Worked
-
-After a successful flash, the board reboots automatically. Here's how to confirm it's working:
-
-1. **Listen for 4 ascending beeps** -- this is the boot confirmation sound. If you hear it, the firmware is running.
-2. On your phone or laptop, look for the WiFi network **`oui-spy`**
-3. Connect with password **`ouispy123`**
-4. Open **http://192.168.4.1** in your browser
-5. You should see the mode selector dashboard
-
-> **No beeps?** The board may not have flashed correctly. Try flashing again with `python3 flash.py --erase` to do a full erase first.
-
-### Batch Mode (Multiple Boards)
-
-For flashing many boards in a row. Fully hands-free -- no button presses or typing between boards.
-
-```bash
-python3 flash.py --batch
-```
-
-**How it works:**
-
-1. The script starts and waits for a board
-2. Plug in a board -- it is detected and flashed automatically
-3. Wait for the board to reboot -- **listen for 4 ascending beeps**. That's your confirmation the flash was successful and the firmware is running.
-4. Unplug the board and plug in the next one -- flashing starts automatically
-5. Repeat until all boards are done
-6. Press **Ctrl+C** to stop
-
-The script never times out. It will wait as long as needed for the next board. It also tracks how many boards were flashed successfully vs. failed.
-
-> **Quick test cycle:** Plug in -> auto-flash -> hear 4 beeps -> unplug -> next board. That's it.
-
-To erase flash completely before writing (clean slate, recommended for first-time flash):
-
-```bash
-python3 flash.py --batch --erase
-```
-
-### What Gets Flashed
-
-The flasher writes all four binary files from the `firmware/` folder in one shot:
-
-| File | Offset | Purpose |
-|------|--------|---------|
-| `bootloader.bin` | `0x0000` | ESP32-S3 bootloader |
-| `partitions.bin` | `0x8000` | Partition table |
-| `boot_app0.bin` | `0xe000` | OTA data partition |
-| `oui-spy-unified-blue.bin` | `0x10000` | Application firmware |
-
-All four files must be present in the `firmware/` folder. The script will warn you if any are missing.
-
-### All Options
-
-```bash
-python3 flash.py                        # flash one board (interactive)
-python3 flash.py --erase                # full erase before flashing
-python3 flash.py --batch                # batch mode: hands-free, auto-detect
-python3 flash.py --batch --erase        # batch + erase (production runs)
-python3 flash.py my_firmware.bin        # flash a specific .bin file
-python3 flash.py --help                 # show help
-```
-
-### Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| `python: command not found` | Use `python3` instead of `python` |
-| `esptool not found` | Run `pip install esptool pyserial` (or `pip3`) |
-| No port detected | Check USB cable is a data cable (not charge-only). Install CH340/CP210x drivers. Try a different USB port. |
-| Board doesn't boot after flash | Make sure all 4 `.bin` files are in `firmware/`. Try `python3 flash.py --erase` to do a full erase first. |
-| Multiple serial devices detected | In single mode, the script lets you pick. In batch mode, it auto-selects. Unplug other USB serial devices if you get unexpected behavior. |
-| Permission denied on serial port | Linux: `sudo usermod -a -G dialout $USER` then log out and back in. macOS: should work out of the box. |
-
-### Building from Source
-
-Only needed if you want to modify the firmware. Requires [PlatformIO](https://platformio.org/).
-
-```bash
-pio run                     # build
-pio run -t upload           # flash directly
-pio device monitor          # serial output (115200 baud)
-```
-
-The build output lands in `.pio/build/seeed_xiao_esp32s3/firmware.bin`. To use the flasher script instead, copy the build artifacts into `firmware/`:
-
-```bash
-cp .pio/build/seeed_xiao_esp32s3/bootloader.bin firmware/
-cp .pio/build/seeed_xiao_esp32s3/partitions.bin firmware/
-cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin firmware/
-cp .pio/build/seeed_xiao_esp32s3/firmware.bin firmware/oui-spy-unified-blue.bin
-```
-
-**Build dependencies** (managed by PlatformIO):
-
-- `NimBLE-Arduino` -- BLE scanning
-- `ESP Async WebServer` + `AsyncTCP` -- web interfaces
-- `ArduinoJson` -- JSON serialization
-- `Adafruit NeoPixel` -- LED control
-
-**Flash layout:** Custom partition table with ~6MB app + ~2MB LittleFS data. See `partitions.csv`.
-
----
-
-## Acknowledgments
-
-**Will Greenberg** ([@wgreenberg](https://github.com/wgreenberg)) — His [flock-you](https://github.com/wgreenberg/flock-you) fork was instrumental in improving the Flock Safety detection heuristics. The BLE manufacturer company ID detection method (`0x09C8` XUNTONG) was sourced directly from his work, along with structured pattern management approaches that informed the detection architecture. Thank you for the research and for making it open.
-
----
-
-## OUI-SPY Firmware Ecosystem
-
-Each firmware is available as a standalone project:
-
-| Firmware | Description | Board |
-|----------|-------------|-------|
-| **[OUI-SPY Unified](https://github.com/colonelpanichacks/oui-spy-unified-blue)** | Multi-mode BLE + WiFi detector (this project) | ESP32-S3 / ESP32-C5 |
-| **[OUI-SPY Detector](https://github.com/colonelpanichacks/ouispy-detector)** | Targeted BLE scanner with OUI filtering | ESP32-S3 |
-| **[OUI-SPY Foxhunter](https://github.com/colonelpanichacks/ouispy-foxhunter)** | RSSI-based proximity tracker | ESP32-S3 |
-| **[Flock You](https://github.com/colonelpanichacks/flock-you)** | Flock Safety / Raven surveillance detection | ESP32-S3 |
-| **[Sky-Spy](https://github.com/colonelpanichacks/Sky-Spy)** | Drone Remote ID detection | ESP32-S3 / ESP32-C5 |
-| **[Remote-ID-Spoofer](https://github.com/colonelpanichacks/Remote-ID-Spoofer)** | WiFi Remote ID spoofer & simulator with swarm mode | ESP32-S3 |
-| **[OUI-SPY UniPwn](https://github.com/colonelpanichacks/Oui-Spy-UniPwn)** | Unitree robot exploitation system | ESP32-S3 |
-
----
-
-## Author
-
-**colonelpanichacks**
-
----
-
-## Disclaimer
-
-This tool is intended for security research, privacy auditing, and educational purposes. Detecting the presence of surveillance hardware in public spaces is legal in most jurisdictions. Always comply with local laws regarding wireless scanning and signal interception. The authors are not responsible for misuse.
+- **colonelpanichacks** — original OUI-SPY Unified firmware
+- **wgreenberg** — Flock Safety BLE manufacturer ID research ([flock-you](https://github.com/wgreenberg/flock-you))

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include "esp_wifi.h"
 #include <TinyGPS++.h>
+#include <math.h>
 
 // ============================================================================
 // CONFIGURATION
@@ -40,14 +41,8 @@
 #define GPS_BAUD   9600
 #define GPS_HDOP_SCALE 5.0f  // HDOP * scale ≈ accuracy in meters
 
-// Audio
-#define LOW_FREQ 200
-#define HIGH_FREQ 800
-#define DETECT_FREQ 1000
-#define HEARTBEAT_FREQ 600
-#define BOOT_BEEP_DURATION 300
-#define DETECT_BEEP_DURATION 150
-#define HEARTBEAT_DURATION 100
+// Audio (LEDC channel 0, initialized in setup())
+// Frequencies are set dynamically in fyCaw() and fyBeep()
 
 // NeoPixel
 #define FY_NEOPIXEL_PIN 4
@@ -185,6 +180,22 @@ static unsigned long fyLastSave = 0;
 static int fyLastSaveCount = 0;  // Track changes to avoid unnecessary writes
 static bool fySpiffsReady = false;
 
+// RSSI distance estimation (log-distance path-loss model)
+// distance = 10 ^ ((txPower - RSSI) / (10 * n))
+#define FY_DEFAULT_TX_POWER -59  // Typical BLE measured power at 1m (dBm)
+#define FY_DEFAULT_PL_N     2.5f // Path-loss exponent (suburban default)
+#define FY_PL_N_MIN         1.6f
+#define FY_PL_N_MAX         4.5f
+static float fyPathLossN = FY_DEFAULT_PL_N;
+static int   fyTxPower   = FY_DEFAULT_TX_POWER;
+
+static float fyEstimateDistance(int rssi) {
+    if (rssi >= 0) return 0.0f;
+    float exponent = (float)(fyTxPower - rssi) / (10.0f * fyPathLossN);
+    float dist = powf(10.0f, exponent);
+    return (dist > 999.0f) ? 999.0f : dist;  // Cap at 999m
+}
+
 // ============================================================================
 // AUDIO SYSTEM
 // ============================================================================
@@ -202,6 +213,7 @@ static void fyBeep(int freq, int dur) {
 static void fyCaw(int startFreq, int endFreq, int durationMs, int warbleHz) {
     if (!fyBuzzerOn) return;
     int steps = durationMs / 8;  // 8ms per step
+    if (steps <= 0) return;
     float fStep = (float)(endFreq - startFreq) / steps;
     for (int i = 0; i < steps; i++) {
         int f = startFreq + (int)(fStep * i);
@@ -380,7 +392,7 @@ static bool checkRavenUUID(NimBLEAdvertisedDevice* device, char* out_uuid = null
         std::string str = svc.toString();
         for (size_t j = 0; j < sizeof(raven_service_uuids)/sizeof(raven_service_uuids[0]); j++) {
             if (strcasecmp(str.c_str(), raven_service_uuids[j]) == 0) {
-                if (out_uuid) strncpy(out_uuid, str.c_str(), 40);
+                if (out_uuid) { strncpy(out_uuid, str.c_str(), 39); out_uuid[39] = '\0'; }
                 return true;
             }
         }
@@ -502,10 +514,15 @@ static int fyAddDetection(const char* mac, const char* name, int rssi,
         FYDetection& d = fyDet[fyDetCount];
         memset(&d, 0, sizeof(d));
         strncpy(d.mac, mac, sizeof(d.mac) - 1);
-        // Sanitize name for JSON safety
+        // Sanitize name for JSON/HTML/XML safety
         if (name) {
             for (int j = 0; j < (int)sizeof(d.name) - 1 && name[j]; j++) {
-                d.name[j] = (name[j] == '"' || name[j] == '\\') ? '_' : name[j];
+                char c = name[j];
+                if (c == '"' || c == '\\' || c == '<' || c == '>' || c == '&' || c < 0x20) {
+                    d.name[j] = '_';
+                } else {
+                    d.name[j] = c;
+                }
             }
         }
         d.rssi = rssi;
@@ -641,10 +658,11 @@ static void writeDetectionsJSON(AsyncResponseStream *resp) {
             resp->printf(
                 "{\"mac\":\"%s\",\"name\":\"%s\",\"rssi\":%d,\"method\":\"%s\","
                 "\"first\":%lu,\"last\":%lu,\"count\":%d,"
-                "\"raven\":%s,\"fw\":\"%s\"",
+                "\"raven\":%s,\"fw\":\"%s\",\"dist_m\":%.1f",
                 fyDet[i].mac, fyDet[i].name, fyDet[i].rssi, fyDet[i].method,
                 fyDet[i].firstSeen, fyDet[i].lastSeen, fyDet[i].count,
-                fyDet[i].isRaven ? "true" : "false", fyDet[i].ravenFW);
+                fyDet[i].isRaven ? "true" : "false", fyDet[i].ravenFW,
+                fyEstimateDistance(fyDet[i].rssi));
             // Append GPS if present
             if (fyDet[i].hasGPS) {
                 resp->printf(",\"gps\":{\"lat\":%.8f,\"lon\":%.8f,\"acc\":%.1f}",
@@ -754,8 +772,9 @@ static void writeDetectionsKML(AsyncResponseStream *resp) {
             if (d.name[0]) resp->printf("<b>Name:</b> %s<br/>", d.name);
             resp->printf("<b>Method:</b> %s<br/>"
                          "<b>RSSI:</b> %d dBm<br/>"
+                         "<b>Distance:</b> ~%.0f m<br/>"
                          "<b>Count:</b> %d<br/>",
-                         d.method, d.rssi, d.count);
+                         d.method, d.rssi, fyEstimateDistance(d.rssi), d.count);
             if (d.isRaven) resp->printf("<b>Raven FW:</b> %s<br/>", d.ravenFW);
             resp->printf("<b>Accuracy:</b> %.1f m", d.gpsAcc);
             resp->print("]]></description>\n");
@@ -840,6 +859,25 @@ h4{color:#ec4899;font-size:14px;margin-bottom:8px}
 <button class="btn" onclick="location.href='/api/history/kml'" style="background:#22c55e">DOWNLOAD PREV KML</button>
 <hr class="sep">
 <button class="btn dng" onclick="if(confirm('Clear all detections?'))fetch('/api/clear').then(()=>refresh())">CLEAR ALL DETECTIONS</button>
+<hr class="sep">
+<h4>RADIO SETTINGS</h4>
+<p style="font-size:10px;color:#8b5cf6;margin-bottom:8px">Adjust path-loss exponent for RSSI distance estimation</p>
+<div style="display:flex;gap:6px;margin-bottom:10px;flex-wrap:wrap">
+<button class="btn" style="flex:1;min-width:80px;padding:6px;font-size:11px;background:#334155" onclick="setN(2.2)">HIGHWAY<br><span style="font-size:9px;opacity:.7">n=2.2</span></button>
+<button class="btn" style="flex:1;min-width:80px;padding:6px;font-size:11px;background:#334155" onclick="setN(2.5)">SUBURBAN<br><span style="font-size:9px;opacity:.7">n=2.5</span></button>
+<button class="btn" style="flex:1;min-width:80px;padding:6px;font-size:11px;background:#334155" onclick="setN(3.0)">URBAN<br><span style="font-size:9px;opacity:.7">n=3.0</span></button>
+<button class="btn" style="flex:1;min-width:80px;padding:6px;font-size:11px;background:#334155" onclick="setN(3.5)">DENSE<br><span style="font-size:9px;opacity:.7">n=3.5</span></button>
+</div>
+<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+<span style="font-size:11px;color:#8b5cf6;min-width:30px">1.6</span>
+<input type="range" id="plSlider" min="16" max="45" value="25" style="flex:1;accent-color:#ec4899" oninput="slidN(this.value)">
+<span style="font-size:11px;color:#8b5cf6;min-width:30px">4.5</span>
+</div>
+<div style="text-align:center;margin-bottom:8px">
+<span style="font-size:16px;font-weight:bold;color:#ec4899" id="plVal">n = 2.5</span>
+<span style="font-size:11px;color:#8b5cf6;margin-left:8px" id="plLabel">(suburban)</span>
+</div>
+<p style="font-size:9px;color:rgba(139,92,246,.5);margin-top:4px">Lower n = open air (highway). Higher n = obstructed (urban). Setting is saved across reboots.</p>
 </div>
 </div>
 <script>
@@ -850,7 +888,10 @@ function render(){const el=document.getElementById('dL');if(!D.length){el.innerH
 D.sort((a,b)=>b.last-a.last);el.innerHTML=D.map(card).join('');}
 function stats(){document.getElementById('sT').textContent=D.length;document.getElementById('sR').textContent=D.filter(d=>d.raven).length;
 fetch('/api/stats').then(r=>r.json()).then(s=>{let g=document.getElementById('sG'),gl=document.getElementById('sGL');if(s.gps_src==='hw'){g.textContent=s.gps_sats+'sat';g.style.color='#22c55e';gl.textContent='HW GPS';}else if(s.gps_src==='phone'){gl.textContent='PHONE';/* let sendGPS control the main indicator */}else if(s.gps_hw_detected){g.textContent=s.gps_sats+'sat';g.style.color='#facc15';gl.textContent='NO FIX';}else if(!_gTried){g.textContent='TAP';g.style.color='#ef4444';gl.textContent='GPS';}else{gl.textContent='GPS';}}).catch(()=>{});}
-function card(d){return '<div class="det"><div class="mac">'+d.mac+(d.name?'<span class="nm">'+d.name+'</span>':'')+'</div><div class="inf"><span>RSSI: '+d.rssi+'</span><span>'+d.method+'</span><span style="color:#ec4899;font-weight:bold">&times;'+d.count+'</span>'+(d.raven?'<span class="rv">RAVEN '+d.fw+'</span>':'')+(d.gps?'<span style="color:#22c55e">&#9673; '+d.gps.lat.toFixed(5)+','+d.gps.lon.toFixed(5)+'</span>':'<span style="color:#666">no gps</span>')+'</div></div>';}
+function esc(s){if(!s)return '';return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+function estDist(rssi){if(rssi>=0)return '?';var e=(_txP-rssi)/(10*_plN);var d=Math.pow(10,e);return d>999?'999':Math.round(d);}
+var _plN=2.5,_txP=-59;
+function card(d){var dm=estDist(d.rssi);return '<div class="det"><div class="mac">'+esc(d.mac)+(d.name?'<span class="nm">'+esc(d.name)+'</span>':'')+'</div><div class="inf"><span>RSSI: '+d.rssi+'</span><span style="color:#facc15">~'+dm+'m</span><span>'+esc(d.method)+'</span><span style="color:#ec4899;font-weight:bold">&times;'+d.count+'</span>'+(d.raven?'<span class="rv">RAVEN '+esc(d.fw)+'</span>':'')+(d.gps?'<span style="color:#22c55e">&#9673; '+d.gps.lat.toFixed(5)+','+d.gps.lon.toFixed(5)+'</span>':'<span style="color:#666">no gps</span>')+'</div></div>';}
 function loadHistory(){fetch('/api/history').then(r=>r.json()).then(d=>{H=d;let el=document.getElementById('hL');if(!H.length){el.innerHTML='<div class="empty">No prior session data</div>';return;}
 H.sort((a,b)=>b.last-a.last);el.innerHTML='<div style="font-size:11px;color:#8b5cf6;margin-bottom:8px">'+H.length+' detections from prior session</div>'+H.map(card).join('');window._hL=1;}).catch(()=>{document.getElementById('hL').innerHTML='<div class="empty">No prior session data</div>';});}
 function loadPat(){fetch('/api/patterns').then(r=>r.json()).then(p=>{let h='';
@@ -859,6 +900,13 @@ h+='<div class="pg"><h3>BLE Device Names ('+p.names.length+')</h3><div class="it
 h+='<div class="pg"><h3>BLE Manufacturer IDs ('+p.mfr.length+')</h3><div class="it">'+p.mfr.map(m=>'<span>0x'+m.toString(16).toUpperCase().padStart(4,'0')+'</span>').join('')+'</div></div>';
 h+='<div class="pg"><h3>Raven UUIDs ('+p.raven.length+')</h3><div class="it">'+p.raven.map(u=>'<span style="font-size:8px">'+u+'</span>').join('')+'</div></div>';
 document.getElementById('pC').innerHTML=h;window._pL=1;}).catch(()=>{});}
+// Radio settings (path-loss exponent)
+function plLabel(n){if(n<=2.0)return 'open air';if(n<=2.3)return 'highway';if(n<=2.7)return 'suburban';if(n<=3.2)return 'urban';return 'dense/indoor';}
+function setN(n){_plN=n;document.getElementById('plSlider').value=Math.round(n*10);document.getElementById('plVal').textContent='n = '+n.toFixed(1);document.getElementById('plLabel').textContent='('+plLabel(n)+')';fetch('/api/settings?pl_n='+n).catch(()=>{});render();}
+function slidN(v){var n=v/10;_plN=n;document.getElementById('plVal').textContent='n = '+n.toFixed(1);document.getElementById('plLabel').textContent='('+plLabel(n)+')';render();}
+document.getElementById('plSlider').addEventListener('change',function(){fetch('/api/settings?pl_n='+(_plN)).catch(()=>{});});
+function loadSettings(){fetch('/api/settings').then(r=>r.json()).then(s=>{_plN=s.pl_n||2.5;_txP=s.tx_power||-59;document.getElementById('plSlider').value=Math.round(_plN*10);document.getElementById('plVal').textContent='n = '+_plN.toFixed(1);document.getElementById('plLabel').textContent='('+plLabel(_plN)+')';render();}).catch(()=>{});}
+loadSettings();
 // GPS from phone -> ESP32 (wardriving)
 // Robust GPS with auto-restart, health monitoring, and GrapheneOS support.
 // HTTP works on: Android Chrome with chrome://flags "Insecure origins treated as secure".
@@ -1009,6 +1057,27 @@ static void fySetupServer() {
         }
     });
 
+    // API: Radio settings (path-loss exponent for distance estimation)
+    fyServer.on("/api/settings", HTTP_GET, [](AsyncWebServerRequest *r) {
+        if (r->hasParam("pl_n")) {
+            float n = r->getParam("pl_n")->value().toFloat();
+            if (n >= FY_PL_N_MIN && n <= FY_PL_N_MAX) {
+                fyPathLossN = n;
+                // Save to NVS
+                Preferences p;
+                p.begin("fy-radio", false);
+                p.putFloat("pl_n", fyPathLossN);
+                p.end();
+                printf("[FLOCK-YOU] Path-loss exponent set to %.1f\n", fyPathLossN);
+            }
+        }
+        char buf[96];
+        snprintf(buf, sizeof(buf),
+            "{\"pl_n\":%.1f,\"tx_power\":%d}",
+            fyPathLossN, fyTxPower);
+        r->send(200, "application/json", buf);
+    });
+
     // API: Pattern database
     fyServer.on("/api/patterns", HTTP_GET, [](AsyncWebServerRequest *r) {
         AsyncResponseStream *resp = r->beginResponseStream("application/json");
@@ -1048,21 +1117,22 @@ static void fySetupServer() {
     fyServer.on("/api/export/csv", HTTP_GET, [](AsyncWebServerRequest *r) {
         AsyncResponseStream *resp = r->beginResponseStream("text/csv");
         resp->addHeader("Content-Disposition", "attachment; filename=\"flockyou_detections.csv\"");
-        resp->println("mac,name,rssi,method,first_seen_ms,last_seen_ms,count,is_raven,raven_fw,latitude,longitude,gps_accuracy");
+        resp->println("mac,name,rssi,method,first_seen_ms,last_seen_ms,count,is_raven,raven_fw,latitude,longitude,gps_accuracy,distance_m");
         if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(200)) == pdTRUE) {
             for (int i = 0; i < fyDetCount; i++) {
                 FYDetection& d = fyDet[i];
+                float dist = fyEstimateDistance(d.rssi);
                 if (d.hasGPS) {
-                    resp->printf("\"%s\",\"%s\",%d,\"%s\",%lu,%lu,%d,%s,\"%s\",%.8f,%.8f,%.1f\n",
+                    resp->printf("\"%s\",\"%s\",%d,\"%s\",%lu,%lu,%d,%s,\"%s\",%.8f,%.8f,%.1f,%.1f\n",
                         d.mac, d.name, d.rssi, d.method,
                         d.firstSeen, d.lastSeen, d.count,
                         d.isRaven ? "true" : "false", d.ravenFW,
-                        d.gpsLat, d.gpsLon, d.gpsAcc);
+                        d.gpsLat, d.gpsLon, d.gpsAcc, dist);
                 } else {
-                    resp->printf("\"%s\",\"%s\",%d,\"%s\",%lu,%lu,%d,%s,\"%s\",,,\n",
+                    resp->printf("\"%s\",\"%s\",%d,\"%s\",%lu,%lu,%d,%s,\"%s\",,,,%.1f\n",
                         d.mac, d.name, d.rssi, d.method,
                         d.firstSeen, d.lastSeen, d.count,
-                        d.isRaven ? "true" : "false", d.ravenFW);
+                        d.isRaven ? "true" : "false", d.ravenFW, dist);
                 }
             }
             xSemaphoreGive(fyMutex);
@@ -1129,7 +1199,7 @@ static void fySetupServer() {
             int placed = 0;
             for (JsonObject d : doc.as<JsonArray>()) {
                 JsonObject gps = d["gps"];
-                if (!gps || !gps.containsKey("lat")) continue;
+                if (!gps || !gps["lat"].is<double>()) continue;
                 bool isRaven = d["raven"] | false;
                 resp->printf("<Placemark><name>%s</name>\n", d["mac"] | "?");
                 resp->printf("<styleUrl>#%s</styleUrl>\n", isRaven ? "raven" : "det");
@@ -1235,6 +1305,13 @@ void setup() {
     fyBuzzerOn = bzP.getBool("on", true);
     bzP.end();
 
+    // Read radio settings from NVS
+    Preferences rP;
+    rP.begin("fy-radio", true);
+    fyPathLossN = rP.getFloat("pl_n", FY_DEFAULT_PL_N);
+    if (fyPathLossN < FY_PL_N_MIN || fyPathLossN > FY_PL_N_MAX) fyPathLossN = FY_DEFAULT_PL_N;
+    rP.end();
+
     pinMode(BUZZER_PIN, OUTPUT);
     digitalWrite(BUZZER_PIN, LOW);
 
@@ -1276,6 +1353,7 @@ void setup() {
     printf("\n========================================\n");
     printf("  FLOCK-YOU Surveillance Detector\n");
     printf("  Buzzer: %s\n", fyBuzzerOn ? "ON" : "OFF");
+    printf("  Path-loss n: %.1f\n", fyPathLossN);
     printf("  GPS: auto-detect (L76K on D6/D7)\n");
     printf("========================================\n");
 

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -1168,8 +1168,52 @@ static void fySetupServer() {
         printf("[FLOCK-YOU] All detections cleared (session saved)\n");
     });
 
-    // Captive portal catch-all: redirect any unknown URL to root
+    // ---- Android / iOS / Windows connectivity checks ----
+    // Android checks these URLs to decide if a network has internet.
+    // The captive portal DNS redirects all domains to 192.168.4.1,
+    // so these arrive as local paths. Returning 204 tells Android
+    // "this network has internet" and prevents it from silently
+    // switching back to mobile data.
+    fyServer.on("/generate_204", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(204);
+    });
+    fyServer.on("/gen_204", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(204);
+    });
+    // Google connectivity check (some Android versions)
+    fyServer.on("/connectivitycheck", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(204);
+    });
+    // Apple captive portal check (expects 200 with "Success")
+    fyServer.on("/hotspot-detect.html", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(200, "text/html", "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>");
+    });
+    fyServer.on("/library/test/success.html", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(200, "text/html", "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>");
+    });
+    // Windows NCSI check
+    fyServer.on("/ncsi.txt", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(200, "text/plain", "Microsoft NCSI");
+    });
+    fyServer.on("/connecttest.txt", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(200, "text/plain", "Microsoft Connect Test");
+    });
+    // Firefox captive portal check
+    fyServer.on("/success.txt", HTTP_GET, [](AsyncWebServerRequest *r) {
+        r->send(200, "text/plain", "success\n");
+    });
+
+    // Captive portal catch-all: serve connectivity checks, redirect the rest
     fyServer.onNotFound([](AsyncWebServerRequest *r) {
+        String url = r->url();
+        // Catch any connectivity check pattern we might have missed
+        if (url.indexOf("generate_204") >= 0 || url.indexOf("gen_204") >= 0 ||
+            url.indexOf("connectivitycheck") >= 0 || url.indexOf("ncsi") >= 0 ||
+            url.indexOf("hotspot-detect") >= 0 || url.indexOf("success") >= 0 ||
+            url.indexOf("connecttest") >= 0 || url.indexOf("redirect") >= 0) {
+            r->send(204);
+            return;
+        }
         r->redirect("http://192.168.4.1/");
     });
 

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -191,8 +191,11 @@ static bool fySpiffsReady = false;
 
 static void fyBeep(int freq, int dur) {
     if (!fyBuzzerOn) return;
-    tone(BUZZER_PIN, freq, dur);
-    delay(dur + 50);
+    ledcSetup(0, freq, 8);
+    ledcWrite(0, 127);  // 50% duty cycle
+    delay(dur);
+    ledcWrite(0, 0);
+    delay(50);
 }
 
 // Crow caw: harsh descending sweep with warble texture
@@ -207,10 +210,11 @@ static void fyCaw(int startFreq, int endFreq, int durationMs, int warbleHz) {
             f += ((i % 6 < 3) ? warbleHz : -warbleHz);
         }
         if (f < 100) f = 100;
-        tone(BUZZER_PIN, f, 10);
+        ledcSetup(0, f, 8);
+        ledcWrite(0, 127);
         delay(8);
     }
-    noTone(BUZZER_PIN);
+    ledcWrite(0, 0);
 }
 
 static void fyBootBeep() {
@@ -231,9 +235,8 @@ static void fyBootBeep() {
     delay(80);
 
     // Quick staccato ending "kk-kk"
-    tone(BUZZER_PIN, 600, 25); delay(40);
-    tone(BUZZER_PIN, 550, 25); delay(40);
-    noTone(BUZZER_PIN);
+    ledcSetup(0, 600, 8); ledcWrite(0, 127); delay(25); ledcWrite(0, 0); delay(15);
+    ledcSetup(0, 550, 8); ledcWrite(0, 127); delay(25); ledcWrite(0, 0);
 
     printf("[FLOCK-YOU] *caw caw caw*\n");
 }
@@ -846,7 +849,7 @@ function refresh(){fetch('/api/detections').then(r=>r.json()).then(d=>{D=d;rende
 function render(){const el=document.getElementById('dL');if(!D.length){el.innerHTML='<div class="empty">Scanning for surveillance devices...<br>BLE active on all channels</div>';return;}
 D.sort((a,b)=>b.last-a.last);el.innerHTML=D.map(card).join('');}
 function stats(){document.getElementById('sT').textContent=D.length;document.getElementById('sR').textContent=D.filter(d=>d.raven).length;
-fetch('/api/stats').then(r=>r.json()).then(s=>{let g=document.getElementById('sG'),gl=document.getElementById('sGL');if(s.gps_src==='hw'){g.textContent=s.gps_sats+'sat';g.style.color='#22c55e';gl.textContent='HW GPS';}else if(s.gps_src==='phone'){g.textContent=s.gps_tagged+'/'+s.total;g.style.color='#22c55e';gl.textContent='PHONE';}else if(s.gps_hw_detected){g.textContent=s.gps_sats+'sat';g.style.color='#facc15';gl.textContent='NO FIX';}else{g.textContent='TAP';g.style.color='#ef4444';gl.textContent='GPS';}}).catch(()=>{});}
+fetch('/api/stats').then(r=>r.json()).then(s=>{let g=document.getElementById('sG'),gl=document.getElementById('sGL');if(s.gps_src==='hw'){g.textContent=s.gps_sats+'sat';g.style.color='#22c55e';gl.textContent='HW GPS';}else if(s.gps_src==='phone'){gl.textContent='PHONE';/* let sendGPS control the main indicator */}else if(s.gps_hw_detected){g.textContent=s.gps_sats+'sat';g.style.color='#facc15';gl.textContent='NO FIX';}else if(!_gTried){g.textContent='TAP';g.style.color='#ef4444';gl.textContent='GPS';}else{gl.textContent='GPS';}}).catch(()=>{});}
 function card(d){return '<div class="det"><div class="mac">'+d.mac+(d.name?'<span class="nm">'+d.name+'</span>':'')+'</div><div class="inf"><span>RSSI: '+d.rssi+'</span><span>'+d.method+'</span><span style="color:#ec4899;font-weight:bold">&times;'+d.count+'</span>'+(d.raven?'<span class="rv">RAVEN '+d.fw+'</span>':'')+(d.gps?'<span style="color:#22c55e">&#9673; '+d.gps.lat.toFixed(5)+','+d.gps.lon.toFixed(5)+'</span>':'<span style="color:#666">no gps</span>')+'</div></div>';}
 function loadHistory(){fetch('/api/history').then(r=>r.json()).then(d=>{H=d;let el=document.getElementById('hL');if(!H.length){el.innerHTML='<div class="empty">No prior session data</div>';return;}
 H.sort((a,b)=>b.last-a.last);el.innerHTML='<div style="font-size:11px;color:#8b5cf6;margin-bottom:8px">'+H.length+' detections from prior session</div>'+H.map(card).join('');window._hL=1;}).catch(()=>{document.getElementById('hL').innerHTML='<div class="empty">No prior session data</div>';});}
@@ -857,26 +860,88 @@ h+='<div class="pg"><h3>BLE Manufacturer IDs ('+p.mfr.length+')</h3><div class="
 h+='<div class="pg"><h3>Raven UUIDs ('+p.raven.length+')</h3><div class="it">'+p.raven.map(u=>'<span style="font-size:8px">'+u+'</span>').join('')+'</div></div>';
 document.getElementById('pC').innerHTML=h;window._pL=1;}).catch(()=>{});}
 // GPS from phone -> ESP32 (wardriving)
-// NOTE: Geolocation API needs secure context (HTTPS) on most browsers.
-// HTTP works on: Android Chrome (local IPs), some Android browsers.
+// Robust GPS with auto-restart, health monitoring, and GrapheneOS support.
+// HTTP works on: Android Chrome with chrome://flags "Insecure origins treated as secure".
 // Won't work on: iOS Safari (needs HTTPS always).
-// We only request on user tap (gesture) for best permission prompt chance.
-let _gW=null,_gOk=false,_gTried=false;
-function sendGPS(p){_gOk=true;let g=document.getElementById('sG');g.textContent='OK';g.style.color='#22c55e';
-fetch('/api/gps?lat='+p.coords.latitude+'&lon='+p.coords.longitude+'&acc='+(p.coords.accuracy||0)).catch(()=>{});}
-function gpsErr(e){_gOk=false;let g=document.getElementById('sG');
-var msg='ERR';if(e.code===1){msg='DENIED';g.style.color='#ef4444';alert('GPS permission denied. On iPhone, GPS requires HTTPS which this device cannot provide. On Android Chrome, tap the lock/info icon in the address bar and allow Location.');}
-else if(e.code===2){msg='N/A';g.style.color='#ef4444';}
-else if(e.code===3){msg='WAIT';g.style.color='#facc15';}
-g.textContent=msg;}
-function startGPS(){if(!navigator.geolocation){return false;}
-if(_gW!==null){navigator.geolocation.clearWatch(_gW);_gW=null;}
-let g=document.getElementById('sG');g.textContent='...';g.style.color='#facc15';
-_gW=navigator.geolocation.watchPosition(sendGPS,gpsErr,{enableHighAccuracy:true,maximumAge:5000,timeout:15000});return true;}
-function reqGPS(){if(!navigator.geolocation){alert('GPS not available in this browser.');return;}
-if(_gOk){return;}
-if(!window.isSecureContext){alert('GPS requires a secure context (HTTPS). This HTTP page may not get GPS permission.\\n\\nAndroid Chrome: try chrome://flags and enable "Insecure origins treated as secure", add http://192.168.4.1\\n\\niPhone: GPS will not work over HTTP.');}
-startGPS();_gTried=true;}
+let _gW=null,_gOk=false,_gTried=false,_gLastFix=0,_gDenied=false,_gSendFails=0;
+const GPS_HEALTH_MS=10000;   // check GPS health every 10s
+const GPS_STALE_JS=20000;    // restart watch if no fix for 20s (must be < ESP32 GPS_STALE_MS of 30s)
+const GPS_MAX_AGE=15000;     // accept cached positions up to 15s old (GrapheneOS can be slow)
+const GPS_TIMEOUT=30000;     // allow 30s for position (GrapheneOS device-only GPS needs time)
+
+function sendGPS(p){
+  _gOk=true;_gLastFix=Date.now();_gSendFails=0;
+  let g=document.getElementById('sG');g.style.color='#22c55e';
+  g.textContent=p.coords.accuracy<50?'OK':'~'+Math.round(p.coords.accuracy)+'m';
+  fetch('/api/gps?lat='+p.coords.latitude+'&lon='+p.coords.longitude+'&acc='+(p.coords.accuracy||0))
+    .then(r=>{if(!r.ok)_gSendFails++;})
+    .catch(()=>{_gSendFails++;if(_gSendFails>3){g.textContent='SEND';g.style.color='#facc15';}});
+}
+
+function gpsErr(e){
+  let g=document.getElementById('sG');
+  if(e.code===1){
+    _gDenied=true;_gOk=false;g.textContent='DENIED';g.style.color='#ef4444';
+    alert('GPS permission denied.\n\nAndroid Chrome: tap the lock/info icon in the address bar and allow Location.\n\nAlso check chrome://flags -> "Insecure origins treated as secure" includes http://192.168.4.1\n\niPhone: GPS will not work over HTTP.');
+  } else if(e.code===2){
+    g.textContent='N/A';g.style.color='#ef4444';
+  } else if(e.code===3){
+    // Timeout — don't panic, watch continues. Show waiting state.
+    g.textContent='WAIT';g.style.color='#facc15';
+    // If watch has been silent too long, force restart
+    if(_gLastFix>0 && Date.now()-_gLastFix>GPS_STALE_JS){restartGPS();}
+  }
+}
+
+function startGPS(){
+  if(!navigator.geolocation||_gDenied)return false;
+  if(_gW!==null){navigator.geolocation.clearWatch(_gW);_gW=null;}
+  let g=document.getElementById('sG');g.textContent='...';g.style.color='#facc15';
+  _gW=navigator.geolocation.watchPosition(sendGPS,gpsErr,{
+    enableHighAccuracy:true,
+    maximumAge:GPS_MAX_AGE,
+    timeout:GPS_TIMEOUT
+  });
+  return true;
+}
+
+function restartGPS(){
+  if(_gDenied)return;
+  if(_gW!==null){navigator.geolocation.clearWatch(_gW);_gW=null;}
+  _gOk=false;
+  startGPS();
+}
+
+// Health monitor: runs on the poll interval, restarts watch if stale
+function checkGPSHealth(){
+  if(!_gTried||_gDenied)return;
+  let g=document.getElementById('sG');
+  // If we had a fix but it went stale, restart the watch
+  if(_gLastFix>0 && Date.now()-_gLastFix>GPS_STALE_JS){
+    g.textContent='LOST';g.style.color='#facc15';
+    restartGPS();
+  }
+  // If watch was started but never delivered a fix after 45s, restart
+  if(!_gOk && _gTried && _gW!==null && _gLastFix===0){
+    let age=Date.now()-(_gStartTime||Date.now());
+    if(age>45000){restartGPS();}
+  }
+}
+
+let _gStartTime=0;
+function reqGPS(){
+  if(!navigator.geolocation){alert('GPS not available in this browser.');return;}
+  if(_gDenied){alert('GPS was denied. Reload the page and allow location permission when prompted.');return;}
+  // Allow re-tap even if _gOk, so user can force restart if GPS seems stuck
+  if(!window.isSecureContext&&!_gTried){
+    alert('GPS requires a secure context.\n\nAndroid Chrome: go to chrome://flags and enable "Insecure origins treated as secure", then add http://192.168.4.1 and relaunch.\n\niPhone: GPS will not work over HTTP.');
+  }
+  _gStartTime=Date.now();
+  startGPS();_gTried=true;
+}
+
+// Run GPS health check alongside the existing stats poll
+setInterval(checkGPSHealth,GPS_HEALTH_MS);
 refresh();setInterval(refresh,2500);
 </script></body></html>
 )rawliteral";
@@ -1128,6 +1193,11 @@ void setup() {
 
     pinMode(BUZZER_PIN, OUTPUT);
     digitalWrite(BUZZER_PIN, LOW);
+
+    // Init LEDC for buzzer (channel 0, 2kHz default, 8-bit resolution)
+    ledcSetup(0, 2000, 8);
+    ledcAttachPin(BUZZER_PIN, 0);
+    ledcWrite(0, 0);  // Start silent
 
     // Init NeoPixel
     fyPixel.begin();


### PR DESCRIPTION
## Summary

Fixes two issues in Flock-You mode: GPS signal lock dropping silently during wardriving sessions, and the LEDC buzzer initialization error on boot that causes muffled audio.

## GPS Fixes

The browser Geolocation API's `watchPosition` can silently stop delivering updates when the phone screen locks, Chrome backgrounds the tab, or the OS throttles location services. The original code had no recovery mechanism — GPS would go stale and new detections would stop getting tagged with coordinates.

**Changes:**
- Added GPS health monitor that checks every 10 seconds and automatically restarts `watchPosition` when the last fix is older than 20 seconds (before the ESP32's 30-second stale threshold expires)
- Increased `maximumAge` from 5s to 15s and `timeout` from 15s to 30s to accommodate device-only GPS (no network assist), which is common on privacy-focused Android setups like GrapheneOS
- Removed the `_gOk` guard that prevented re-initialization after a successful fix — tapping the GPS card now always restarts the watch, giving users a manual override
- Added `fetch` failure tracking in `sendGPS` — after 3 consecutive failed sends, the UI shows "SEND" in yellow so the user knows the ESP32 isn't receiving coordinates
- Fixed `stats()` overriding JavaScript-managed GPS state — previously the 2.5-second poll would reset the indicator to "TAP" (red) whenever the ESP32 reported `gps_src=none`, even with an active watch
- GPS indicator now shows accuracy in meters when >50m, so users can distinguish rough network fixes from proper GPS locks
- Fixed double-escaped `\n` in alert messages that displayed as literal `\n\n` instead of line breaks

## Buzzer Fixes

The boot crow caw sound was muffled and threw `E ledc: ledc_get_duty: LEDC is not initialized` errors because `tone()` was called before the LEDC peripheral was ready.

**Changes:**
- Added explicit LEDC channel 0 initialization in `setup()` before any audio plays
- Replaced all `tone()`/`noTone()` calls with direct `ledcSetup()`/`ledcWrite()` control, matching the approach used by Foxhunter and other modes

## Testing

Tested on XIAO ESP32-S3 with Pixel 7a running GrapheneOS. GPS lock maintained during extended wardriving session. LEDC error eliminated, crow caw plays cleanly on boot.