### PR TITLE
expansion board, mode selector and dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 # firmware/*.bin
 __pycache__/
 .venv/
+nul
+package.json
+package-lock.json
+src/idf_component.yml
+src/idf_component.yml.orig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Note: Mode IDs 3 is skipped intentionally.
 - **LED:** GPIO 21 has inverted logic (LOW = ON). Optional NeoPixel on GPIO 4.
 - **Embedded HTML:** Stored as `PROGMEM` raw string literals with `%PLACEHOLDER%` template substitution.
 - **Device cooldowns:** Detection modes use timed cooldowns (3s or 30s) to prevent alert spam on the same device.
-- **Sky Spy differs:** Uses WiFi promiscuous mode (not BLE) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`.
+- **Sky Spy differs:** Uses WiFi promiscuous mode (+ BLE passive scan) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`. Outputs full JSON on USB Serial (every detection) and compact human-readable messages on Serial1 pins 5/6 (throttled to 5s) for Heltec LoRa/Meshtastic mesh forwarding. Serial1 is harmless when no mesh hardware is connected.
 
 ### Hardware
 
@@ -100,6 +100,8 @@ Note: Mode IDs 3 is skipped intentionally.
 | 0 | BOOT button (hold 2s → return to selector) |
 | 3 | Piezo buzzer (PWM, inverted logic) |
 | 4 | NeoPixel LED (optional) |
+| 5 / D4 | Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy) |
+| 6 / D5 | Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy) |
 | 21 | Onboard LED (inverted logic) |
 
 ### Dependencies (managed by PlatformIO)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Hard Rules — DO NOT VIOLATE
+
+### Never modify global PlatformIO packages
+- **NEVER** modify, rename, delete, or overwrite files in `~/.platformio/packages/`. This is a shared global directory that affects ALL PlatformIO projects on the system.
+- If a build needs a different framework version, use `platform_packages` overrides in `platformio.ini` — never manually swap framework directories.
+- If two targets need incompatible frameworks, use **separate project directories**, not the same shared package directory.
+
+### Never make system-wide changes for project-local problems
+- Scope all changes to the project directory. If a workaround requires touching files outside the project, stop and find a project-local solution instead.
+- Before modifying anything in `~/.platformio/`, `~/.config/`, or any global path, ask the user for explicit permission and explain the blast radius.
+
+### Always clean build after framework changes
+- If the PlatformIO framework package was modified or reinstalled for any reason, always run `pio run -t clean` before building. Stale bootloader binaries from a wrong framework cause unrecoverable boot loops (`ets_loader.c 78`).
+
+### Verify hardware claims with manufacturer documentation
+- Do not assume GPIO mappings, onboard peripherals (LEDs, NeoPixels), or antenna configurations based on similar boards. Always verify against the manufacturer's official documentation (e.g., Seeed Wiki) before writing code that depends on specific hardware features.
+
+## Project Overview
+
+OUI-SPY Unified Blue is a multi-mode firmware for the **Seeed Studio XIAO ESP32-S3**. It provides a unified bootloader with 4 selectable firmware modes for surveillance device detection and drone monitoring, all running on a single device with a WiFi-based boot selector.
+
+**Modes:** Detector (BLE scanner with OUI/MAC watchlists), Foxhunter (RSSI proximity tracker), Flock-You (Flock Safety / Raven surveillance device detector), Sky Spy (FAA Remote ID / Open Drone ID drone detector).
+
+## Build & Flash Commands
+
+```bash
+pio run                     # Build firmware
+pio run -t upload           # Build and flash via USB
+pio run -t clean            # Clean build artifacts
+pio device monitor          # Serial monitor (115200 baud)
+python flash.py             # Flash pre-compiled bin from firmware/ folder
+python flash.py --erase     # Full erase before flashing
+```
+
+Build output: `.pio/build/seeed_xiao_esp32s3/firmware.bin`
+
+There are no automated tests. Validation is done by flashing to hardware and testing each mode.
+
+## Architecture
+
+### Unified Bootloader (`src/main.cpp`)
+
+The entry point. On boot it checks the BOOT button (GPIO 0), reads the stored mode from NVS, and dispatches to the selected mode's `setup()`/`loop()` functions. Mode 0 (Selector) serves a WiFi AP with a web UI for choosing modes and configuring AP credentials/buzzer. Holding BOOT for 2s from any mode returns to the selector.
+
+### Mode Wrapper Pattern
+
+Each mode's original standalone firmware lives unmodified in `src/raw/`. Wrapper files (`src/mode_*.cpp`) encapsulate them using this pattern to avoid linker symbol collisions:
+
+```cpp
+#define setup modename_ns_setup
+#define loop  modename_ns_loop
+namespace {
+    #include "raw/modename.cpp"    // Original firmware included verbatim
+}
+#undef setup
+#undef loop
+void modename_setup() { modename_ns_setup(); }
+void modename_loop()  { modename_ns_loop(); }
+```
+
+The `#define` renames Arduino's `setup`/`loop`, the anonymous namespace gives all symbols internal linkage, and the exported `modename_setup()`/`modename_loop()` functions are declared in `src/modes.h` and called from `main.cpp`.
+
+**Critical:** Files in `src/raw/` are excluded from direct compilation via `src_filter = +<*> -<raw/>` in `platformio.ini`. They are only compiled through `#include` in the wrapper files. Do not add them to the build filter.
+
+### Mode-to-File Mapping
+
+| Mode | ID | Wrapper | Implementation | AP |
+|------|----|---------|----------------|----|
+| Selector | 0 | `main.cpp` | `main.cpp` | `oui-spy` / `ouispy123` |
+| Detector | 1 | `mode_detector.cpp` | `raw/detector.cpp` | `snoopuntothem` / `astheysnoopuntous` |
+| Foxhunter | 2 | `mode_foxhunter.cpp` | `raw/foxhunter.cpp` | `foxhunter` / `foxhunter` |
+| Flock-You | 4 | `mode_flockyou.cpp` | `raw/flockyou.cpp` | `flockyou` / `flockyou123` |
+| Sky Spy | 5 | `mode_skyspy.cpp` | `raw/skyspy.cpp` | No AP (passive WiFi scanner) |
+
+Note: Mode IDs 3 is skipped intentionally.
+
+### Key Patterns
+
+- **NVS persistence:** `Preferences` library stores mode selection (`"unified-mode"` namespace), AP credentials (`"ouispy-ap"`), and buzzer state (`"ouispy-bz"`). Always call `prefs.end()` after use.
+- **WiFi factory reset on boot:** `esp_wifi_restore()` clears stale NVS WiFi config every boot before mode init.
+- **MAC randomization:** Random locally-administered MAC generated on each boot via `esp_random()`.
+- **Async web servers:** All modes with dashboards use `ESPAsyncWebServer` on port 80 at `192.168.4.1`.
+- **BLE scanning:** NimBLE library with `NimBLEAdvertisedDeviceCallbacks` for advertisement processing.
+- **Buzzer audio:** LEDC PWM on GPIO 3 (inverted logic). Frequencies range from 600 Hz (heartbeat) to 3000 Hz (confirmation).
+- **LED:** GPIO 21 has inverted logic (LOW = ON). Optional NeoPixel on GPIO 4.
+- **Embedded HTML:** Stored as `PROGMEM` raw string literals with `%PLACEHOLDER%` template substitution.
+- **Device cooldowns:** Detection modes use timed cooldowns (3s or 30s) to prevent alert spam on the same device.
+- **Sky Spy differs:** Uses WiFi promiscuous mode (not BLE) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`.
+
+### Hardware
+
+**Board:** Seeed Studio XIAO ESP32-S3 with PSRAM. Custom partition table: ~6MB app + ~2MB LittleFS (`partitions.csv`).
+
+| GPIO | Function |
+|------|----------|
+| 0 | BOOT button (hold 2s → return to selector) |
+| 3 | Piezo buzzer (PWM, inverted logic) |
+| 4 | NeoPixel LED (optional) |
+| 21 | Onboard LED (inverted logic) |
+
+### Dependencies (managed by PlatformIO)
+
+- `NimBLE-Arduino` ^1.4.0 — BLE scanning
+- `ESP Async WebServer` ^3.0.6 — Web interfaces
+- `ArduinoJson` ^7.0.4 — JSON serialization
+- `Adafruit NeoPixel` ^1.12.0 — LED control
+
+## ESP32-C6 Experimental Branch
+
+An experimental standalone Flock-You build for the XIAO ESP32-C6 exists on the `esp32c6-flockyou` branch (release: `esp32c6-v1.0`). It is NOT on master. If working on C6 support in the future, use a **separate project directory** to avoid framework conflicts with the S3 build.
+
+## Git Identity (this repo)
+
+- user.name: suteny0r
+- user.email: suteny0r@gmail.com
+- Fork remote: https://github.com/suteny0r/oui-spy-unified-blue
+
+### Never push to upstream origin
+- This is a fork. `origin` points to the upstream repo (`colonelpanichacks/oui-spy-unified-blue`) which we do **not** have write access to.
+- **ALWAYS** push to `fork` (e.g., `git push fork master`), **NEVER** to `origin`.
+- When creating PRs, push the branch to `fork` first, then open the PR against the upstream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,13 @@ Note: Mode IDs 3 is skipped intentionally.
 |------|----------|
 | 0 | BOOT button (hold 2s → return to selector) |
 | 2 / D1 | Expansion board USER button (active low, internal pull-up) |
-| 3 | Piezo buzzer (PWM, inverted logic) |
-| 4 | NeoPixel LED (optional) |
+| 3 | Buzzer (external oui-spy piezo, PWM; see note below) |
+| 4 / D3 | Expansion board buzzer (A3) when chassis present; else optional NeoPixel LED |
 | 5 / D4 | Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy) |
 | 6 / D5 | Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy) |
 | 21 | Onboard LED (inverted logic) |
+
+**Buzzer routing:** the oui-spy build drives an external piezo on GPIO3 (D2). The **Seeed Studio XIAO Expansion Board** carries its own passive buzzer on **GPIO4 (D3/A3)**. When the expansion board is detected (`dashboard_present()`), `dashboard_buzzer_pin()` returns GPIO4 and every mode routes its `BUZZER_PIN` there instead; GPIO4 then cannot drive the optional NeoPixel, so Detector and Flock-You skip NeoPixel init/animations while the chassis is present.
 
 ### Expansion Board OLED Dashboard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Note: Mode IDs 3 is skipped intentionally.
 - **LED:** GPIO 21 has inverted logic (LOW = ON). Optional NeoPixel on GPIO 4.
 - **Embedded HTML:** Stored as `PROGMEM` raw string literals with `%PLACEHOLDER%` template substitution.
 - **Device cooldowns:** Detection modes use timed cooldowns (3s or 30s) to prevent alert spam on the same device.
-- **Sky Spy differs:** Uses WiFi promiscuous mode (+ BLE passive scan) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`. Outputs full JSON on USB Serial (every detection) and compact human-readable messages on Serial1 pins 5/6 (throttled to 5s) for Heltec LoRa/Meshtastic mesh forwarding. Serial1 is harmless when no mesh hardware is connected.
+- **Sky Spy differs:** Uses WiFi promiscuous mode (+ BLE passive scan) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`. Outputs full JSON on USB Serial (every detection) AND a Serial1 line per detection whose format is gated by expansion board presence: headless builds send compact human-readable messages on pins 5/6 for the Heltec LoRa/Meshtastic gateway (unchanged legacy behavior); when the expansion board is detected the full JSON line is sent on the Grove UART (GPIO43 TX / GPIO44 RX) for a second XIAO ESP32-S3 running the `sky-spy-relay` firmware, which publishes it to MQTT.
 - **Expansion board dashboard:** Shared `src/dashboard.h` / `src/dashboard.cpp` module (U8g2) that auto-detects the expansion board OLED on I2C and no-ops when absent. Modes call `dashboard_init()` early, then draw with `dashboard_*()` helpers; the USER button advances multi-page dashboards.
 
 ### Hardware
@@ -102,8 +102,10 @@ Note: Mode IDs 3 is skipped intentionally.
 | 2 / D1 | Expansion board USER button (active low, internal pull-up) |
 | 3 | Buzzer (external oui-spy piezo, PWM; see note below) |
 | 4 / D3 | Expansion board buzzer (A3) when chassis present; else optional NeoPixel LED |
-| 5 / D4 | Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy) |
-| 6 / D5 | Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy) |
+| 5 / D4 | OLED I2C SDA (expansion board); Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy, headless) |
+| 6 / D5 | OLED I2C SCL (expansion board); Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy, headless) |
+| 43 / D6 | Serial1 TX — relay UART to sky-spy-relay (Sky Spy, expansion board present); Grove UART TX |
+| 44 / D7 | Serial1 RX — relay UART from sky-spy-relay (Sky Spy, expansion board present); Grove UART RX |
 | 21 | Onboard LED (inverted logic) |
 
 **Buzzer routing:** the oui-spy build drives an external piezo on GPIO3 (D2). The **Seeed Studio XIAO Expansion Board** carries its own passive buzzer on **GPIO4 (D3/A3)**. When the expansion board is detected (`dashboard_present()`), `dashboard_buzzer_pin()` returns GPIO4 and every mode routes its `BUZZER_PIN` there instead; GPIO4 then cannot drive the optional NeoPixel, so Detector and Flock-You skip NeoPixel init/animations while the chassis is present.
@@ -113,10 +115,18 @@ Note: Mode IDs 3 is skipped intentionally.
 The **Seeed Studio Expansion Base for XIAO** carries a 0.96" 128x64 SSD1306-family OLED (SSD1315) plus a USER button. Shared driver: `src/dashboard.h` / `src/dashboard.cpp` (uses U8g2, detected by I2C probe at `0x3C`/`0x3D`). On the XIAO ESP32S3 the OLED is on **GPIO5 (SDA) / GPIO6 (SCL)** and the button on **GPIO2**.
 
 - **Auto-detect, never required:** `dashboard_init()` probes the I2C bus; if nothing answers it releases the pins and every other `dashboard_*` call becomes a no-op, so modes behave exactly as before with no display.
-- **Pin conflict with Sky Spy mesh UART:** the OLED and the Serial1 mesh UART share GPIO5/6. Sky Spy calls `dashboard_init()` before `Serial1.begin()`; when the OLED is present it disables Serial1 (`send_mesh_message()` returns early). Headless builds keep full mesh forwarding.
+- **Sky Spy Serial1 output is gated by expansion board presence:** headless builds send compact mesh messages to the Heltec LoRa/Meshtastic gateway on GPIO5/6 (unchanged legacy behavior). When the OLED is present, GPIO5/6 belong to the display and Serial1 moves to the Grove UART pins GPIO43/44 (`dashboard_present()` selects the pins in `initializeSerial()`), carrying the full JSON detection stream for the `sky-spy-relay` board. `dashboard_init()` runs before `Serial1.begin()` to probe the OLED and pick the correct pins.
 - **Multi-page dashboards:** the USER button (GPIO2) advances pages. Sky Spy implements 4 pages (Summary, Latest Drone, Position, Fleet) via the `dashPage*()` render functions in `src/raw/skyspy.cpp`, redrawn at 1 Hz.
 - `dashboard_printf` uses U8g2's `setCursor(x, y)` where **y is the text baseline** (font `u8g2_font_5x7_tr` ascent = 6), so row `i` lives at `y = 6 + i*8`.
 - All draw/press calls are safe no-ops until `dashboard_init()` returns true. Call `dashboard_init()` before any other peripheral claims GPIO5/6.
+
+### Relay UART (Sky Spy)
+
+The Sky Spy relay UART (`Serial1`, 115200 8N1) lives on the expansion board's **Grove UART** connector, which is wired to **GPIO43 (TX / D6) and GPIO44 (RX / D7)** on the XIAO ESP32-S3. It carries one full JSON detection line per detection. A second XIAO ESP32-S3 running `sky-spy-relay` receives this stream and publishes it to MQTT (`skyspy/<topic>/raw` and `skyspy/<topic>/detections`). The Grove UART pins do NOT overlap the OLED on GPIO5/6, so the OLED dashboard and the relay stream coexist on the same board. This relay path is only active when the expansion board is detected; headless builds keep the legacy compact mesh messages on GPIO5/6.
+
+Note: GPIO43/44 are the same pins Flock-You uses for its hardware GPS (Seeed L76K GNSS). This is fine because Flock-You and Sky Spy are never active at the same time (mode selection reboots the board).
+
+Pins claimed by other hardware: GPIO0 (BOOT button), GPIO2 (USER button), GPIO3 (external buzzer), GPIO4 (expansion buzzer / optional NeoPixel), GPIO5/6 (OLED I2C), GPIO21 (onboard LED), GPIO43/44 (Sky Spy relay UART / Flock-You GPS). Free XIAO header pins: **D0 (GPIO1), D8 (GPIO7), D9 (GPIO8), D10 (GPIO9), D11 (GPIO42), D12 (GPIO41)**.
 
 ### Dependencies (managed by PlatformIO)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Note: Mode IDs 3 is skipped intentionally.
 - **Embedded HTML:** Stored as `PROGMEM` raw string literals with `%PLACEHOLDER%` template substitution.
 - **Device cooldowns:** Detection modes use timed cooldowns (3s or 30s) to prevent alert spam on the same device.
 - **Sky Spy differs:** Uses WiFi promiscuous mode (+ BLE passive scan) to capture ASTM F3411 Open Drone ID frames. The OpenDroneID parser is in `src/opendroneid.h/c` and `src/wifi.c`. Outputs full JSON on USB Serial (every detection) and compact human-readable messages on Serial1 pins 5/6 (throttled to 5s) for Heltec LoRa/Meshtastic mesh forwarding. Serial1 is harmless when no mesh hardware is connected.
+- **Expansion board dashboard:** Shared `src/dashboard.h` / `src/dashboard.cpp` module (U8g2) that auto-detects the expansion board OLED on I2C and no-ops when absent. Modes call `dashboard_init()` early, then draw with `dashboard_*()` helpers; the USER button advances multi-page dashboards.
 
 ### Hardware
 
@@ -98,11 +99,22 @@ Note: Mode IDs 3 is skipped intentionally.
 | GPIO | Function |
 |------|----------|
 | 0 | BOOT button (hold 2s → return to selector) |
+| 2 / D1 | Expansion board USER button (active low, internal pull-up) |
 | 3 | Piezo buzzer (PWM, inverted logic) |
 | 4 | NeoPixel LED (optional) |
 | 5 / D4 | Serial1 TX — mesh UART to Heltec LoRa gateway (Sky Spy) |
 | 6 / D5 | Serial1 RX — mesh UART from Heltec LoRa gateway (Sky Spy) |
 | 21 | Onboard LED (inverted logic) |
+
+### Expansion Board OLED Dashboard
+
+The **Seeed Studio Expansion Base for XIAO** carries a 0.96" 128x64 SSD1306-family OLED (SSD1315) plus a USER button. Shared driver: `src/dashboard.h` / `src/dashboard.cpp` (uses U8g2, detected by I2C probe at `0x3C`/`0x3D`). On the XIAO ESP32S3 the OLED is on **GPIO5 (SDA) / GPIO6 (SCL)** and the button on **GPIO2**.
+
+- **Auto-detect, never required:** `dashboard_init()` probes the I2C bus; if nothing answers it releases the pins and every other `dashboard_*` call becomes a no-op, so modes behave exactly as before with no display.
+- **Pin conflict with Sky Spy mesh UART:** the OLED and the Serial1 mesh UART share GPIO5/6. Sky Spy calls `dashboard_init()` before `Serial1.begin()`; when the OLED is present it disables Serial1 (`send_mesh_message()` returns early). Headless builds keep full mesh forwarding.
+- **Multi-page dashboards:** the USER button (GPIO2) advances pages. Sky Spy implements 4 pages (Summary, Latest Drone, Position, Fleet) via the `dashPage*()` render functions in `src/raw/skyspy.cpp`, redrawn at 1 Hz.
+- `dashboard_printf` uses U8g2's `setCursor(x, y)` where **y is the text baseline** (font `u8g2_font_5x7_tr` ascent = 6), so row `i` lives at `y = 6 + i*8`.
+- All draw/press calls are safe no-ops until `dashboard_init()` returns true. Call `dashboard_init()` before any other peripheral claims GPIO5/6.
 
 ### Dependencies (managed by PlatformIO)
 
@@ -110,6 +122,7 @@ Note: Mode IDs 3 is skipped intentionally.
 - `ESP Async WebServer` ^3.0.6 — Web interfaces
 - `ArduinoJson` ^7.0.4 — JSON serialization
 - `Adafruit NeoPixel` ^1.12.0 — LED control
+- `U8g2` ^2.36.18 — expansion board OLED driver
 
 ## ESP32-C6 Experimental Branch
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ lib_deps =
     mathieucarbou/ESP Async WebServer@^3.0.6
     adafruit/Adafruit NeoPixel@^1.12.0
     bblanchon/ArduinoJson@^7.0.4
+    mikalhart/TinyGPSPlus@^1.1.0
 
 ; Board configuration
 board_build.arduino.memory_type = qio_opi

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     bblanchon/ArduinoJson@^7.0.4
     mikalhart/TinyGPSPlus@^1.1.0
+    olikraus/U8g2@^2.36.18
 
 ; Board configuration
 board_build.arduino.memory_type = qio_opi

--- a/src/dashboard.cpp
+++ b/src/dashboard.cpp
@@ -1,0 +1,131 @@
+/*
+ * Shared dashboard module for the Seeed Studio Expansion Base for XIAO.
+ *
+ * The expansion board carries a 0.96" 128x64 SSD1306-family OLED (SSD1315)
+ * wired to the XIAO header I2C pins, plus a user button on the D1 position.
+ * On the XIAO ESP32S3 the I2C pins are GPIO5 (SDA / D4) and GPIO6 (SCL / D5),
+ * and the button is GPIO2.
+ *
+ * Every function is a safe no-op until a display is detected, so modes keep
+ * working exactly as before when no expansion board is attached. Detection is
+ * done by probing the I2C bus at the SSD1306/SSD1315 addresses; when nothing
+ * answers, the bus is released so other peripherals (e.g. Sky Spy's Serial1
+ * mesh UART on the same two pins) can claim them.
+ */
+
+#include "dashboard.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <Wire.h>
+#include <U8g2lib.h>
+
+static U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(
+    U8G2_R0, U8X8_PIN_NONE, DISPLAY_SCL_PIN, DISPLAY_SDA_PIN);
+
+static bool displayPresent = false;
+
+bool dashboard_init() {
+    static bool alreadyTried = false;
+    if (alreadyTried) return displayPresent;
+    alreadyTried = true;
+
+    // Probe the bus before committing, so the I2C pins are released back to
+    // GPIO when no display is attached. On Sky Spy those pins double as the
+    // Serial1 mesh UART, so dashboard_init() must run before Serial1.begin().
+    Wire.begin(DISPLAY_SDA_PIN, DISPLAY_SCL_PIN);
+    bool found = false;
+    uint8_t addrs[] = { DISPLAY_ADDR_0, DISPLAY_ADDR_1 };
+    for (size_t i = 0; i < sizeof(addrs); i++) {
+        Wire.beginTransmission(addrs[i]);
+        if (Wire.endTransmission() == 0) { found = true; break; }
+    }
+    Wire.end();
+
+    dashboard_button_init();
+
+    if (!found) {
+        Serial.println("[DASH] No OLED display detected - running headless");
+        return false;
+    }
+
+    Serial.println("[DASH] SSD1306/SSD1315 OLED display detected");
+    displayPresent = true;
+    u8g2.begin();
+    u8g2.setFont(u8g2_font_5x7_tr);
+    u8g2.setDrawColor(1);
+    u8g2.clearBuffer();
+    u8g2.sendBuffer();
+    return true;
+}
+
+bool dashboard_present() { return displayPresent; }
+
+void dashboard_clear() {
+    if (!displayPresent) return;
+    u8g2.clearBuffer();
+}
+
+void dashboard_flush() {
+    if (!displayPresent) return;
+    u8g2.sendBuffer();
+}
+
+void dashboard_set_font(const uint8_t *font) {
+    if (!displayPresent) return;
+    u8g2.setFont(font);
+}
+
+void dashboard_set_draw_color(uint8_t color) {
+    if (!displayPresent) return;
+    u8g2.setDrawColor(color);
+}
+
+void dashboard_set_cursor(uint16_t x, uint16_t y) {
+    if (!displayPresent) return;
+    u8g2.setCursor(x, y);
+}
+
+void dashboard_printf(const char *fmt, ...) {
+    if (!displayPresent) return;
+    char buf[64];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    u8g2.print(buf);
+}
+
+void dashboard_draw_hline(uint16_t x, uint16_t y, uint16_t w) {
+    if (!displayPresent) return;
+    u8g2.drawHLine(x, y, w);
+}
+
+void dashboard_draw_box(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+    if (!displayPresent) return;
+    u8g2.drawBox(x, y, w, h);
+}
+
+void dashboard_button_init() {
+    pinMode(DISPLAY_BUTTON_PIN, INPUT_PULLUP);
+}
+
+bool dashboard_button_pressed() {
+    static uint32_t lastChange = 0;
+    static bool lastRaw = HIGH;
+    static bool stable = HIGH;
+    static bool prevStable = HIGH;
+
+    bool raw = digitalRead(DISPLAY_BUTTON_PIN);
+    uint32_t now = millis();
+    if (raw != lastRaw) {
+        lastRaw = raw;
+        lastChange = now;
+    }
+    if (now - lastChange >= 40) {
+        stable = raw;
+    }
+
+    bool fresh = (prevStable == HIGH && stable == LOW);  // falling edge
+    prevStable = stable;
+    return fresh;
+}

--- a/src/dashboard.cpp
+++ b/src/dashboard.cpp
@@ -60,6 +60,10 @@ bool dashboard_init() {
 
 bool dashboard_present() { return displayPresent; }
 
+int dashboard_buzzer_pin() {
+    return displayPresent ? BUZZER_PIN_EXPANSION : BUZZER_PIN_EXTERNAL;
+}
+
 void dashboard_clear() {
     if (!displayPresent) return;
     u8g2.clearBuffer();

--- a/src/dashboard.cpp
+++ b/src/dashboard.cpp
@@ -16,8 +16,10 @@
 #include "dashboard.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 #include <Wire.h>
 #include <U8g2lib.h>
+#include "qrcode.h"
 
 static U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(
     U8G2_R0, U8X8_PIN_NONE, DISPLAY_SCL_PIN, DISPLAY_SDA_PIN);
@@ -107,6 +109,46 @@ void dashboard_draw_hline(uint16_t x, uint16_t y, uint16_t w) {
 void dashboard_draw_box(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
     if (!displayPresent) return;
     u8g2.drawBox(x, y, w, h);
+}
+
+// QR version -> byte-mode data capacity at ECC_LOW (versions 1-3 are the ones
+// that render at a scannable 2 px/module on a 128x64 display).
+static const uint16_t QR_BYTE_CAPACITY[3] = { 17, 32, 53 };
+
+bool dashboard_draw_qrcode(const char *text) {
+    if (!displayPresent) return true;
+    if (!text) return false;
+
+    size_t len = strlen(text);
+    uint8_t version = 0;
+    uint16_t bufferSize = 0;
+    for (uint8_t v = 1; v <= 3; v++) {
+        if (len <= QR_BYTE_CAPACITY[v - 1]) {
+            version = v;
+            bufferSize = qrcode_getBufferSize(v);
+            break;
+        }
+    }
+    if (version == 0) return false;  // too long to stay scannable here
+
+    uint8_t qrcodeData[bufferSize];
+    QRCode qr;
+    qrcode_initText(&qr, qrcodeData, version, ECC_LOW, text);
+
+    int size = qr.size;          // modules per side (4*version + 17)
+    int scale = 2;               // px per module
+    int px = size * scale;
+    int x0 = (128 - px) / 2;
+    int y0 = (64 - px) / 2;
+
+    for (int y = 0; y < size; y++) {
+        for (int x = 0; x < size; x++) {
+            if (qrcode_getModule(&qr, (uint8_t)x, (uint8_t)y)) {
+                u8g2.drawBox(x0 + x * scale, y0 + y * scale, scale, scale);
+            }
+        }
+    }
+    return true;
 }
 
 void dashboard_button_init() {

--- a/src/dashboard.h
+++ b/src/dashboard.h
@@ -59,6 +59,11 @@ void dashboard_printf(const char *fmt, ...);
 void dashboard_draw_hline(uint16_t x, uint16_t y, uint16_t w);
 void dashboard_draw_box(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
 
+// Generate a QR code for `text` and draw it centered on the display, scaled to
+// fit. Returns false (and draws nothing) when the text is too long to encode in
+// a QR that stays scannable on this 128x64 display.
+bool dashboard_draw_qrcode(const char *text);
+
 // Expansion board user button (active low, internal pull-up).
 void dashboard_button_init();
 // True once per fresh press (debounced, edge-triggered).

--- a/src/dashboard.h
+++ b/src/dashboard.h
@@ -16,6 +16,17 @@
 // which is GPIO2 on the XIAO ESP32S3. Active low with the internal pull-up.
 #define DISPLAY_BUTTON_PIN 2
 
+// Buzzer hardware routing.
+// The oui-spy build drives an external piezo buzzer on GPIO3 (D2). The Seeed
+// Studio XIAO Expansion Board carries its own passive buzzer on GPIO4 (D3/A3).
+// When the expansion board is detected, buzzer output is routed to GPIO4
+// instead, so GPIO4 must not be used for the optional NeoPixel.
+#define BUZZER_PIN_EXTERNAL 3
+#define BUZZER_PIN_EXPANSION 4
+
+// Pin to drive the buzzer on for the currently attached hardware.
+int dashboard_buzzer_pin();
+
 // Probe the I2C bus and init the OLED when present. Returns true once a
 // display is attached. When absent, every other dashboard_* call is a safe
 // no-op, so firmware behavior is unchanged. Call this before any other

--- a/src/dashboard.h
+++ b/src/dashboard.h
@@ -1,0 +1,56 @@
+#ifndef DASHBOARD_H
+#define DASHBOARD_H
+
+#include <Arduino.h>
+
+// 0.96" 128x64 OLED on the Seeed Studio Expansion Base for XIAO.
+// XIAO ESP32S3 I2C pins: SDA = GPIO5 (D4), SCL = GPIO6 (D5).
+// WARNING: these are the same pins Sky Spy uses for its Serial1 mesh UART,
+// so the dashboard is mutually exclusive with mesh forwarding on that mode.
+#define DISPLAY_SDA_PIN 5
+#define DISPLAY_SCL_PIN 6
+#define DISPLAY_ADDR_0 0x3C
+#define DISPLAY_ADDR_1 0x3D
+
+// User button on the expansion board. It is wired to the D1 header position,
+// which is GPIO2 on the XIAO ESP32S3. Active low with the internal pull-up.
+#define DISPLAY_BUTTON_PIN 2
+
+// Probe the I2C bus and init the OLED when present. Returns true once a
+// display is attached. When absent, every other dashboard_* call is a safe
+// no-op, so firmware behavior is unchanged. Call this before any other
+// peripheral claims DISPLAY_SDA_PIN/DISPLAY_SCL_PIN.
+bool dashboard_init();
+
+// True once a display has been detected and initialized.
+bool dashboard_present();
+
+// Clear the framebuffer (start of a frame).
+void dashboard_clear();
+
+// Push the framebuffer to the display (end of a frame).
+void dashboard_flush();
+
+// Select the U8g2 font used by subsequent text (see U8g2lib.h for symbols).
+void dashboard_set_font(const uint8_t *font);
+
+// Set the U8g2 draw color (1 = draw, 0 = erase). Lets callers invert text on a
+// filled box to highlight menu selections.
+void dashboard_set_draw_color(uint8_t color);
+
+// Move the text cursor to pixel position (x, y).
+void dashboard_set_cursor(uint16_t x, uint16_t y);
+
+// Formatted text at the current cursor.
+void dashboard_printf(const char *fmt, ...);
+
+// Simple primitives (all in pixels).
+void dashboard_draw_hline(uint16_t x, uint16_t y, uint16_t w);
+void dashboard_draw_box(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+
+// Expansion board user button (active low, internal pull-up).
+void dashboard_button_init();
+// True once per fresh press (debounced, edge-triggered).
+bool dashboard_button_pressed();
+
+#endif // DASHBOARD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,9 +219,11 @@ static void selectorBeep() {
 // menu as an alternative to the web UI:
 //   - TAP the USER button  -> advance the highlighted mode
 //   - HOLD the USER button -> boot the highlighted mode
-// The WiFi AP / web UI keeps working alongside it.
+// The WiFi AP / web UI keeps working alongside it. If the user does not
+// interact for MENU_TIMEOUT_MS, the menu resumes the last active mode.
 #define MENU_MODES_COUNT 4
 #define MENU_HOLD_BOOT_MS 1500
+#define MENU_TIMEOUT_MS 30000
 
 static const uint8_t MENU_MODES[MENU_MODES_COUNT] = { 1, 2, 4, 5 };
 static const char* MENU_LABELS[MENU_MODES_COUNT] = {
@@ -237,6 +239,7 @@ static bool menuDirty = true;
 static unsigned long menuBtnDown = 0;
 static bool menuBtnWasDown = false;
 static bool menuBtnLongDone = false;
+static unsigned long lastMenuActivity = 0;
 
 static void renderSelectorMenu(unsigned long now) {
     if (!dashboard_present()) return;
@@ -308,6 +311,50 @@ static void bootSelectedMode() {
     ESP.restart();
 }
 
+// Boots the last active mode (stored in NVS) when the OLED menu times out.
+// Returns true when it actually reboots, false if there is no last mode to
+// resume (in which case the menu keeps waiting).
+static bool resumeLastMode() {
+    prefs.begin("unified-mode", true);
+    int mode = prefs.getInt("mode", 0);
+    prefs.end();
+
+    // Valid modes are 1, 2, 4, 5 (mode 3 is intentionally skipped).
+    if (mode != 1 && mode != 2 && mode != 4 && mode != 5) {
+        Serial.println("[SELECTOR] Menu timeout - no last mode to resume, staying in menu");
+        Serial.flush();
+        return false;
+    }
+
+    // One-shot flag: the next boot goes straight into this mode, not the menu.
+    Preferences menuPrefs;
+    menuPrefs.begin("ouispy-menu", false);
+    menuPrefs.putBool("boot", true);
+    menuPrefs.end();
+
+    Serial.printf("[SELECTOR] Menu timeout - resuming last mode %d\n", mode);
+    Serial.flush();
+
+    // Confirmation feedback
+    for (int i = 0; i < 2; i++) {
+        playNote(800 + i * 150, 100);
+        delay(30);
+    }
+
+    if (dashboard_present()) {
+        dashboard_clear();
+        dashboard_set_cursor(0, MENU_BASELINE + 0 * MENU_ROW_STEP);
+        dashboard_printf("RESUMING MODE %d", mode);
+        dashboard_set_cursor(0, MENU_BASELINE + 2 * MENU_ROW_STEP);
+        dashboard_printf("LAST ACTIVE MODE");
+        dashboard_flush();
+        delay(1000);
+    }
+
+    ESP.restart();
+    return true;  // never reached
+}
+
 // Handles the USER button: tap advances, hold boots. Call every loop tick.
 static void handleSelectorMenu(unsigned long now) {
     if (!dashboard_present()) return;
@@ -333,6 +380,7 @@ static void handleSelectorMenu(unsigned long now) {
         if (!menuBtnLongDone && now - menuBtnDown >= 30) {
             menuIndex = (menuIndex + 1) % MENU_MODES_COUNT;
             menuDirty = true;
+            lastMenuActivity = now;
             Serial.printf("[SELECTOR] OLED menu highlight: %s (mode %d)\n",
                           MENU_LABELS[menuIndex], MENU_MODES[menuIndex]);
             Serial.flush();
@@ -401,6 +449,18 @@ static void startSelector() {
     if (dashboard_present()) {
         Serial.println("[SELECTOR] OLED detected - on-screen mode menu enabled");
         menuDirty = true;
+        // Position the highlight on the last active mode so the user can see
+        // what the menu will auto-boot into on timeout.
+        prefs.begin("unified-mode", true);
+        int lastMode = prefs.getInt("mode", 0);
+        prefs.end();
+        for (uint8_t i = 0; i < MENU_MODES_COUNT; i++) {
+            if (MENU_MODES[i] == lastMode) {
+                menuIndex = i;
+                break;
+            }
+        }
+        lastMenuActivity = millis();
         renderSelectorMenu(millis());
     }
     
@@ -762,6 +822,15 @@ void loop() {
             // OLED mode menu (when expansion board display present)
             handleSelectorMenu(millis());
             renderSelectorMenu(millis());
+            // Menu timeout: after 30s without interaction, resume the last mode
+            {
+                unsigned long now = millis();
+                if (dashboard_present() && now - lastMenuActivity >= MENU_TIMEOUT_MS) {
+                    if (!resumeLastMode()) {
+                        lastMenuActivity = now;  // no last mode - keep waiting
+                    }
+                }
+            }
             // LED breathing animation
             {
                 static unsigned long lastLed = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <ESPAsyncWebServer.h>
 #include <Preferences.h>
 #include "modes.h"
+#include "dashboard.h"
 
 // Hardware pins (shared across all modes)
 #define BUZZER_PIN 3
@@ -208,6 +209,134 @@ static void selectorBeep() {
 }
 
 // ============================================================================
+// OLED Mode Selector Menu (expansion board display)
+// ============================================================================
+// When the expansion board OLED is attached, the selector offers an on-screen
+// menu as an alternative to the web UI:
+//   - TAP the USER button  -> advance the highlighted mode
+//   - HOLD the USER button -> boot the highlighted mode
+// The WiFi AP / web UI keeps working alongside it.
+#define MENU_MODES_COUNT 4
+#define MENU_HOLD_BOOT_MS 1500
+
+static const uint8_t MENU_MODES[MENU_MODES_COUNT] = { 1, 2, 4, 5 };
+static const char* MENU_LABELS[MENU_MODES_COUNT] = {
+    "DETECTOR", "FOXHUNTER", "FLOCK-YOU", "SKY SPY"
+};
+
+#define MENU_BASELINE 6
+#define MENU_ROW_STEP 8
+
+static uint8_t menuIndex = 0;
+static unsigned long lastMenuRender = 0;
+static bool menuDirty = true;
+static unsigned long menuBtnDown = 0;
+static bool menuBtnWasDown = false;
+static bool menuBtnLongDone = false;
+
+static void renderSelectorMenu(unsigned long now) {
+    if (!dashboard_present()) return;
+    if (!menuDirty && now - lastMenuRender < 1000) return;
+    menuDirty = false;
+    lastMenuRender = now;
+
+    dashboard_clear();
+    dashboard_set_cursor(0, MENU_BASELINE + 0 * MENU_ROW_STEP);
+    dashboard_printf("OUI-SPY");
+    dashboard_set_cursor(0, MENU_BASELINE + 1 * MENU_ROW_STEP);
+    dashboard_printf("FIRMWARE SELECTOR");
+    dashboard_draw_hline(0, 15, 128);
+
+    for (uint8_t i = 0; i < MENU_MODES_COUNT; i++) {
+        int yBase = MENU_BASELINE + (2 + i) * MENU_ROW_STEP;
+        if (i == menuIndex) {
+            dashboard_draw_box(0, yBase - 6, 128, 7);
+            dashboard_set_draw_color(0);
+            dashboard_set_cursor(0, yBase);
+            dashboard_printf("%s", MENU_LABELS[i]);
+            dashboard_set_draw_color(1);
+        } else {
+            dashboard_set_cursor(0, yBase);
+            dashboard_printf("  %s", MENU_LABELS[i]);
+        }
+    }
+
+    dashboard_set_cursor(0, MENU_BASELINE + 6 * MENU_ROW_STEP);
+    dashboard_printf("TAP NEXT  HOLD BOOT");
+    dashboard_set_cursor(0, MENU_BASELINE + 7 * MENU_ROW_STEP);
+    dashboard_printf("WEB 192.168.4.1");
+    dashboard_flush();
+}
+
+static void bootSelectedMode() {
+    int mode = MENU_MODES[menuIndex];
+    Serial.printf("[SELECTOR] OLED menu: booting mode %d (%s)\n",
+                  mode, MENU_LABELS[menuIndex]);
+    Serial.flush();
+
+    // Write mode to NVS (same path as the web UI /select handler)
+    prefs.begin("unified-mode", false);
+    prefs.putInt("mode", mode);
+    prefs.end();
+
+    // One-shot flag: the next boot goes straight into this mode, not the menu.
+    Preferences menuPrefs;
+    menuPrefs.begin("ouispy-menu", false);
+    menuPrefs.putBool("boot", true);
+    menuPrefs.end();
+
+    // Confirmation feedback
+    for (int i = 0; i < 2; i++) {
+        playNote(1000 + i * 200, 120);
+        delay(30);
+    }
+
+    if (dashboard_present()) {
+        dashboard_clear();
+        dashboard_set_cursor(0, MENU_BASELINE + 0 * MENU_ROW_STEP);
+        dashboard_printf("BOOTING MODE %d", mode);
+        dashboard_set_cursor(0, MENU_BASELINE + 2 * MENU_ROW_STEP);
+        dashboard_printf("%s", MENU_LABELS[menuIndex]);
+        dashboard_flush();
+        delay(1200);
+    }
+
+    ESP.restart();
+}
+
+// Handles the USER button: tap advances, hold boots. Call every loop tick.
+static void handleSelectorMenu(unsigned long now) {
+    if (!dashboard_present()) return;
+
+    bool down = digitalRead(DISPLAY_BUTTON_PIN) == LOW;
+
+    if (down && !menuBtnWasDown) {
+        menuBtnWasDown = true;
+        menuBtnDown = now;
+        menuBtnLongDone = false;
+    }
+
+    if (down && menuBtnWasDown && !menuBtnLongDone &&
+        now - menuBtnDown >= MENU_HOLD_BOOT_MS) {
+        menuBtnLongDone = true;
+        bootSelectedMode();
+        return;
+    }
+
+    if (!down && menuBtnWasDown) {
+        menuBtnWasDown = false;
+        // Debounce release, then treat as a tap
+        if (!menuBtnLongDone && now - menuBtnDown >= 30) {
+            menuIndex = (menuIndex + 1) % MENU_MODES_COUNT;
+            menuDirty = true;
+            Serial.printf("[SELECTOR] OLED menu highlight: %s (mode %d)\n",
+                          MENU_LABELS[menuIndex], MENU_MODES[menuIndex]);
+            Serial.flush();
+        }
+    }
+}
+
+// ============================================================================
 // Boot Button Detection (GPIO0)
 // ============================================================================
 // Hold the BOOT button during startup to return to selector menu.
@@ -260,6 +389,16 @@ static void startSelector() {
     // Load user-configured AP credentials and buzzer setting from NVS
     loadAPConfig();
     loadBuzzerConfig();
+    
+    // Probe for the expansion board OLED. Pins 5/6 are free in this mode, so
+    // this is safe and a no-op when no display is attached. When present, an
+    // on-screen mode menu is offered alongside the web UI.
+    dashboard_init();
+    if (dashboard_present()) {
+        Serial.println("[SELECTOR] OLED detected - on-screen mode menu enabled");
+        menuDirty = true;
+        renderSelectorMenu(millis());
+    }
     
     Serial.println("\n========================================");
     Serial.println("  OUI SPY - Firmware Selector");
@@ -323,6 +462,12 @@ static void startSelector() {
                 prefs.begin("unified-mode", false);
                 prefs.putInt("mode", mode);
                 prefs.end();
+
+                // One-shot flag: next boot lands in this mode, not the menu.
+                Preferences menuPrefs;
+                menuPrefs.begin("ouispy-menu", false);
+                menuPrefs.putBool("boot", true);
+                menuPrefs.end();
                 
                 // Verify the write by reading it back
                 prefs.begin("unified-mode", true);
@@ -483,6 +628,33 @@ void setup() {
     Serial.println("========================================");
     Serial.flush();
     
+    // One-shot flag set by the OLED menu (or web UI) when the user picks a mode:
+    // the next boot must go straight into that mode instead of the selector.
+    bool launchFromMenu = false;
+    {
+        Preferences menuPrefs;
+        menuPrefs.begin("ouispy-menu", true);
+        launchFromMenu = menuPrefs.getBool("boot", false);
+        menuPrefs.end();
+        if (launchFromMenu) {
+            menuPrefs.begin("ouispy-menu", false);
+            menuPrefs.putBool("boot", false);
+            menuPrefs.end();
+        }
+    }
+
+    // If the expansion board OLED is present, the on-screen menu is the default
+    // boot interface: always boot into the selector so the user can pick a mode
+    // with the USER button (unless this boot is the result of a menu selection,
+    // which must land in the chosen mode). This is also the reliable way to reach
+    // the selector, because holding the BOOT button across a reset makes the ROM
+    // enter download mode instead of running the firmware.
+    if (dashboard_init() && currentMode != 0 && !launchFromMenu) {
+        Serial.println("[OUI-SPY] OLED present - booting into selector menu");
+        Serial.flush();
+        currentMode = 0;
+    }
+    
     // Route to selected mode
     Serial.println("\n[OUI-SPY] ========== ROUTING TO MODE ==========");
     Serial.printf("[OUI-SPY] About to switch on currentMode = %d\n", currentMode);
@@ -577,6 +749,9 @@ void loop() {
         case 5: skyspy_loop(); break;
         default:
             // Selector mode - web server handles everything
+            // OLED mode menu (when expansion board display present)
+            handleSelectorMenu(millis());
+            renderSelectorMenu(millis());
             // LED breathing animation
             {
                 static unsigned long lastLed = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,11 @@
 #include "dashboard.h"
 
 // Hardware pins (shared across all modes)
-#define BUZZER_PIN 3
+// Buzzer is routed to the expansion board's buzzer (GPIO4) when the chassis is
+// attached, otherwise the external oui-spy piezo (GPIO3). Set in setup() after
+// dashboard_init().
+static int buzzerPin = BUZZER_PIN_EXTERNAL;
+#define BUZZER_PIN buzzerPin
 #define LED_PIN 21
 
 // Boot button (GPIO0) - held during boot to return to selector menu
@@ -570,6 +574,12 @@ void setup() {
     Serial.println("OUI SPY UNIFIED FIRMWARE v2.0");
     Serial.println("========================================");
     Serial.flush();
+    
+    // Detect the expansion board early so the buzzer is routed to the chassis
+    // buzzer (GPIO4) instead of the external piezo (GPIO3) from the first beep.
+    // This also decides whether the selector boots into its OLED mode menu.
+    dashboard_init();
+    buzzerPin = dashboard_buzzer_pin();
     
     // FIRST THING: Check if BOOT button (GPIO0) is being held
     // Hold BOOT for 1.5 seconds during startup to force selector menu.

--- a/src/mode_detector.cpp
+++ b/src/mode_detector.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <Adafruit_NeoPixel.h>
 #include "modes.h"
+#include "dashboard.h"
 
 // Rename setup/loop to avoid conflict with Arduino entry points
 #define setup detector_ns_setup

--- a/src/mode_flockyou.cpp
+++ b/src/mode_flockyou.cpp
@@ -23,6 +23,7 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <SPIFFS.h>
+#include <TinyGPS++.h>
 #include "modes.h"
 
 // Rename setup/loop

--- a/src/mode_flockyou.cpp
+++ b/src/mode_flockyou.cpp
@@ -24,6 +24,7 @@
 #include <ESPAsyncWebServer.h>
 #include <SPIFFS.h>
 #include <TinyGPS++.h>
+#include <Adafruit_NeoPixel.h>
 #include "modes.h"
 
 // Rename setup/loop

--- a/src/mode_flockyou.cpp
+++ b/src/mode_flockyou.cpp
@@ -26,6 +26,7 @@
 #include <TinyGPS++.h>
 #include <Adafruit_NeoPixel.h>
 #include "modes.h"
+#include "dashboard.h"
 
 // Rename setup/loop
 #define setup flockyou_ns_setup

--- a/src/mode_foxhunter.cpp
+++ b/src/mode_foxhunter.cpp
@@ -15,6 +15,7 @@
 #include <NimBLEAdvertisedDevice.h>
 #include <esp_wifi.h>
 #include "modes.h"
+#include "dashboard.h"
 
 // Rename setup/loop
 #define setup foxhunter_ns_setup

--- a/src/mode_skyspy.cpp
+++ b/src/mode_skyspy.cpp
@@ -20,6 +20,7 @@
 #include <freertos/task.h>
 #include <Preferences.h>
 #include "modes.h"
+#include "dashboard.h"
 
 // Rename setup/loop
 #define setup skyspy_ns_setup

--- a/src/qrcode.c
+++ b/src/qrcode.c
@@ -1,0 +1,876 @@
+/**
+ * The MIT License (MIT)
+ *
+ * This library is written and maintained by Richard Moore.
+ * Major parts were derived from Project Nayuki's library.
+ *
+ * Copyright (c) 2017 Richard Moore     (https://github.com/ricmoo/QRCode)
+ * Copyright (c) 2017 Project Nayuki    (https://www.nayuki.io/page/qr-code-generator-library)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ *  Special thanks to Nayuki (https://www.nayuki.io/) from which this library was
+ *  heavily inspired and compared against.
+ *
+ *  See: https://github.com/nayuki/QR-Code-generator/tree/master/cpp
+ */
+
+#include "qrcode.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#pragma mark - Error Correction Lookup tables
+
+#if LOCK_VERSION == 0
+
+static const uint16_t NUM_ERROR_CORRECTION_CODEWORDS[4][40] = {
+    // 1,  2,  3,  4,  5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,   25,   26,   27,   28,   29,   30,   31,   32,   33,   34,   35,   36,   37,   38,   39,   40    Error correction level
+    { 10, 16, 26, 36, 48,  64,  72,  88, 110, 130, 150, 176, 198, 216, 240, 280, 308, 338, 364, 416, 442, 476, 504, 560,  588,  644,  700,  728,  784,  812,  868,  924,  980, 1036, 1064, 1120, 1204, 1260, 1316, 1372},  // Medium
+    {  7, 10, 15, 20, 26,  36,  40,  48,  60,  72,  80,  96, 104, 120, 132, 144, 168, 180, 196, 224, 224, 252, 270, 300,  312,  336,  360,  390,  420,  450,  480,  510,  540,  570,  570,  600,  630,  660,  720,  750},  // Low
+    { 17, 28, 44, 64, 88, 112, 130, 156, 192, 224, 264, 308, 352, 384, 432, 480, 532, 588, 650, 700, 750, 816, 900, 960, 1050, 1110, 1200, 1260, 1350, 1440, 1530, 1620, 1710, 1800, 1890, 1980, 2100, 2220, 2310, 2430},  // High
+    { 13, 22, 36, 52, 72,  96, 108, 132, 160, 192, 224, 260, 288, 320, 360, 408, 448, 504, 546, 600, 644, 690, 750, 810,  870,  952, 1020, 1050, 1140, 1200, 1290, 1350, 1440, 1530, 1590, 1680, 1770, 1860, 1950, 2040},  // Quartile
+};
+
+static const uint8_t NUM_ERROR_CORRECTION_BLOCKS[4][40] = {
+    // Version: (note that index 0 is for padding, and is set to an illegal value)
+    // 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40    Error correction level
+    {  1, 1, 1, 2, 2, 4, 4, 4, 5, 5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49},  // Medium
+    {  1, 1, 1, 1, 1, 2, 2, 2, 2, 4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25},  // Low
+    {  1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81},  // High
+    {  1, 1, 2, 2, 4, 4, 6, 6, 8, 8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68},  // Quartile
+};
+
+static const uint16_t NUM_RAW_DATA_MODULES[40] = {
+    //  1,   2,   3,   4,    5,    6,    7,    8,    9,   10,   11,   12,   13,   14,   15,   16,   17,
+      208, 359, 567, 807, 1079, 1383, 1568, 1936, 2336, 2768, 3232, 3728, 4256, 4651, 5243, 5867, 6523,
+    //   18,   19,   20,   21,    22,    23,    24,    25,   26,    27,     28,    29,    30,    31,
+       7211, 7931, 8683, 9252, 10068, 10916, 11796, 12708, 13652, 14628, 15371, 16411, 17483, 18587,
+    //    32,    33,    34,    35,    36,    37,    38,    39,    40
+       19723, 20891, 22091, 23008, 24272, 25568, 26896, 28256, 29648
+};
+
+// @TODO: Put other LOCK_VERSIONS here
+#elif LOCK_VERSION == 3
+
+static const int16_t NUM_ERROR_CORRECTION_CODEWORDS[4] = {
+    26, 15, 44, 36
+};
+
+static const int8_t NUM_ERROR_CORRECTION_BLOCKS[4] = {
+    1, 1, 2, 2
+};
+
+static const uint16_t NUM_RAW_DATA_MODULES = 567;
+
+#else
+
+#error Unsupported LOCK_VERSION (add it...)
+
+#endif
+
+
+static int max(int a, int b) {
+    if (a > b) { return a; }
+    return b;
+}
+
+/*
+static int abs(int value) {
+    if (value < 0) { return -value; }
+    return value;
+}
+*/
+
+
+#pragma mark - Mode testing and conversion
+
+static int8_t getAlphanumeric(char c) {
+    
+    if (c >= '0' && c <= '9') { return (c - '0'); }
+    if (c >= 'A' && c <= 'Z') { return (c - 'A' + 10); }
+    
+    switch (c) {
+        case ' ': return 36;
+        case '$': return 37;
+        case '%': return 38;
+        case '*': return 39;
+        case '+': return 40;
+        case '-': return 41;
+        case '.': return 42;
+        case '/': return 43;
+        case ':': return 44;
+    }
+    
+    return -1;
+}
+
+static bool isAlphanumeric(const char *text, uint16_t length) {
+    while (length != 0) {
+        if (getAlphanumeric(text[--length]) == -1) { return false; }
+    }
+    return true;
+}
+
+
+static bool isNumeric(const char *text, uint16_t length) {
+    while (length != 0) {
+        char c = text[--length];
+        if (c < '0' || c > '9') { return false; }
+    }
+    return true;
+}
+
+
+#pragma mark - Counting
+
+// We store the following tightly packed (less 8) in modeInfo
+//               <=9  <=26  <= 40
+// NUMERIC      ( 10,   12,    14);
+// ALPHANUMERIC (  9,   11,    13);
+// BYTE         (  8,   16,    16);
+static char getModeBits(uint8_t version, uint8_t mode) {
+    // Note: We use 15 instead of 16; since 15 doesn't exist and we cannot store 16 (8 + 8) in 3 bits
+    // hex(int("".join(reversed([('00' + bin(x - 8)[2:])[-3:] for x in [10, 9, 8, 12, 11, 15, 14, 13, 15]])), 2))
+    unsigned int modeInfo = 0x7bbb80a;
+    
+#if LOCK_VERSION == 0 || LOCK_VERSION > 9
+    if (version > 9) { modeInfo >>= 9; }
+#endif
+    
+#if LOCK_VERSION == 0 || LOCK_VERSION > 26
+    if (version > 26) { modeInfo >>= 9; }
+#endif
+    
+    char result = 8 + ((modeInfo >> (3 * mode)) & 0x07);
+    if (result == 15) { result = 16; }
+    
+    return result;
+}
+
+
+#pragma mark - BitBucket
+
+typedef struct BitBucket {
+    uint32_t bitOffsetOrWidth;
+    uint16_t capacityBytes;
+    uint8_t *data;
+} BitBucket;
+
+/*
+void bb_dump(BitBucket *bitBuffer) {
+    printf("Buffer: ");
+    for (uint32_t i = 0; i < bitBuffer->capacityBytes; i++) {
+        printf("%02x", bitBuffer->data[i]);
+        if ((i % 4) == 3) { printf(" "); }
+    }
+    printf("\n");
+}
+*/
+
+static uint16_t bb_getGridSizeBytes(uint8_t size) {
+    return (((size * size) + 7) / 8);
+}
+
+static uint16_t bb_getBufferSizeBytes(uint32_t bits) {
+    return ((bits + 7) / 8);
+}
+
+static void bb_initBuffer(BitBucket *bitBuffer, uint8_t *data, int32_t capacityBytes) {
+    bitBuffer->bitOffsetOrWidth = 0;
+    bitBuffer->capacityBytes = capacityBytes;
+    bitBuffer->data = data;
+    
+    memset(data, 0, bitBuffer->capacityBytes);
+}
+
+static void bb_initGrid(BitBucket *bitGrid, uint8_t *data, uint8_t size) {
+    bitGrid->bitOffsetOrWidth = size;
+    bitGrid->capacityBytes = bb_getGridSizeBytes(size);
+    bitGrid->data = data;
+
+    memset(data, 0, bitGrid->capacityBytes);
+}
+
+static void bb_appendBits(BitBucket *bitBuffer, uint32_t val, uint8_t length) {
+    uint32_t offset = bitBuffer->bitOffsetOrWidth;
+    for (int8_t i = length - 1; i >= 0; i--, offset++) {
+        bitBuffer->data[offset >> 3] |= ((val >> i) & 1) << (7 - (offset & 7));
+    }
+    bitBuffer->bitOffsetOrWidth = offset;
+}
+/*
+void bb_setBits(BitBucket *bitBuffer, uint32_t val, int offset, uint8_t length) {
+    for (int8_t i = length - 1; i >= 0; i--, offset++) {
+        bitBuffer->data[offset >> 3] |= ((val >> i) & 1) << (7 - (offset & 7));
+    }
+}
+*/
+static void bb_setBit(BitBucket *bitGrid, uint8_t x, uint8_t y, bool on) {
+    uint32_t offset = y * bitGrid->bitOffsetOrWidth + x;
+    uint8_t mask = 1 << (7 - (offset & 0x07));
+    if (on) {
+        bitGrid->data[offset >> 3] |= mask;
+    } else {
+        bitGrid->data[offset >> 3] &= ~mask;
+    }
+}
+
+static void bb_invertBit(BitBucket *bitGrid, uint8_t x, uint8_t y, bool invert) {
+    uint32_t offset = y * bitGrid->bitOffsetOrWidth + x;
+    uint8_t mask = 1 << (7 - (offset & 0x07));
+    bool on = ((bitGrid->data[offset >> 3] & (1 << (7 - (offset & 0x07)))) != 0);
+    if (on ^ invert) {
+        bitGrid->data[offset >> 3] |= mask;
+    } else {
+        bitGrid->data[offset >> 3] &= ~mask;
+    }
+}
+
+static bool bb_getBit(BitBucket *bitGrid, uint8_t x, uint8_t y) {
+    uint32_t offset = y * bitGrid->bitOffsetOrWidth + x;
+    return (bitGrid->data[offset >> 3] & (1 << (7 - (offset & 0x07)))) != 0;
+}
+
+
+#pragma mark - Drawing Patterns
+
+// XORs the data modules in this QR Code with the given mask pattern. Due to XOR's mathematical
+// properties, calling applyMask(m) twice with the same value is equivalent to no change at all.
+// This means it is possible to apply a mask, undo it, and try another mask. Note that a final
+// well-formed QR Code symbol needs exactly one mask applied (not zero, not two, etc.).
+static void applyMask(BitBucket *modules, BitBucket *isFunction, uint8_t mask) {
+    uint8_t size = modules->bitOffsetOrWidth;
+    
+    for (uint8_t y = 0; y < size; y++) {
+        for (uint8_t x = 0; x < size; x++) {
+            if (bb_getBit(isFunction, x, y)) { continue; }
+            
+            bool invert = 0;
+            switch (mask) {
+                case 0:  invert = (x + y) % 2 == 0;                    break;
+                case 1:  invert = y % 2 == 0;                          break;
+                case 2:  invert = x % 3 == 0;                          break;
+                case 3:  invert = (x + y) % 3 == 0;                    break;
+                case 4:  invert = (x / 3 + y / 2) % 2 == 0;            break;
+                case 5:  invert = x * y % 2 + x * y % 3 == 0;          break;
+                case 6:  invert = (x * y % 2 + x * y % 3) % 2 == 0;    break;
+                case 7:  invert = ((x + y) % 2 + x * y % 3) % 2 == 0;  break;
+            }
+            bb_invertBit(modules, x, y, invert);
+        }
+    }
+}
+
+static void setFunctionModule(BitBucket *modules, BitBucket *isFunction, uint8_t x, uint8_t y, bool on) {
+    bb_setBit(modules, x, y, on);
+    bb_setBit(isFunction, x, y, true);
+}
+
+// Draws a 9*9 finder pattern including the border separator, with the center module at (x, y).
+static void drawFinderPattern(BitBucket *modules, BitBucket *isFunction, uint8_t x, uint8_t y) {
+    uint8_t size = modules->bitOffsetOrWidth;
+
+    for (int8_t i = -4; i <= 4; i++) {
+        for (int8_t j = -4; j <= 4; j++) {
+            uint8_t dist = max(abs(i), abs(j));  // Chebyshev/infinity norm
+            int16_t xx = x + j, yy = y + i;
+            if (0 <= xx && xx < size && 0 <= yy && yy < size) {
+                setFunctionModule(modules, isFunction, xx, yy, dist != 2 && dist != 4);
+            }
+        }
+    }
+}
+
+// Draws a 5*5 alignment pattern, with the center module at (x, y).
+static void drawAlignmentPattern(BitBucket *modules, BitBucket *isFunction, uint8_t x, uint8_t y) {
+    for (int8_t i = -2; i <= 2; i++) {
+        for (int8_t j = -2; j <= 2; j++) {
+            setFunctionModule(modules, isFunction, x + j, y + i, max(abs(i), abs(j)) != 1);
+        }
+    }
+}
+
+// Draws two copies of the format bits (with its own error correction code)
+// based on the given mask and this object's error correction level field.
+static void drawFormatBits(BitBucket *modules, BitBucket *isFunction, uint8_t ecc, uint8_t mask) {
+    
+    uint8_t size = modules->bitOffsetOrWidth;
+
+    // Calculate error correction code and pack bits
+    uint32_t data = ecc << 3 | mask;  // errCorrLvl is uint2, mask is uint3
+    uint32_t rem = data;
+    for (int i = 0; i < 10; i++) {
+        rem = (rem << 1) ^ ((rem >> 9) * 0x537);
+    }
+    
+    data = data << 10 | rem;
+    data ^= 0x5412;  // uint15
+    
+    // Draw first copy
+    for (uint8_t i = 0; i <= 5; i++) {
+        setFunctionModule(modules, isFunction, 8, i, ((data >> i) & 1) != 0);
+    }
+    
+    setFunctionModule(modules, isFunction, 8, 7, ((data >> 6) & 1) != 0);
+    setFunctionModule(modules, isFunction, 8, 8, ((data >> 7) & 1) != 0);
+    setFunctionModule(modules, isFunction, 7, 8, ((data >> 8) & 1) != 0);
+    
+    for (int8_t i = 9; i < 15; i++) {
+        setFunctionModule(modules, isFunction, 14 - i, 8, ((data >> i) & 1) != 0);
+    }
+    
+    // Draw second copy
+    for (int8_t i = 0; i <= 7; i++) {
+        setFunctionModule(modules, isFunction, size - 1 - i, 8, ((data >> i) & 1) != 0);
+    }
+    
+    for (int8_t i = 8; i < 15; i++) {
+        setFunctionModule(modules, isFunction, 8, size - 15 + i, ((data >> i) & 1) != 0);
+    }
+    
+    setFunctionModule(modules, isFunction, 8, size - 8, true);
+}
+
+
+// Draws two copies of the version bits (with its own error correction code),
+// based on this object's version field (which only has an effect for 7 <= version <= 40).
+static void drawVersion(BitBucket *modules, BitBucket *isFunction, uint8_t version) {
+    
+    int8_t size = modules->bitOffsetOrWidth;
+
+#if LOCK_VERSION != 0 && LOCK_VERSION < 7
+    return;
+    
+#else
+    if (version < 7) { return; }
+    
+    // Calculate error correction code and pack bits
+    uint32_t rem = version;  // version is uint6, in the range [7, 40]
+    for (uint8_t i = 0; i < 12; i++) {
+        rem = (rem << 1) ^ ((rem >> 11) * 0x1F25);
+    }
+    
+    uint32_t data = version << 12 | rem;  // uint18
+    
+    // Draw two copies
+    for (uint8_t i = 0; i < 18; i++) {
+        bool bit = ((data >> i) & 1) != 0;
+        uint8_t a = size - 11 + i % 3, b = i / 3;
+        setFunctionModule(modules, isFunction, a, b, bit);
+        setFunctionModule(modules, isFunction, b, a, bit);
+    }
+    
+#endif
+}
+
+static void drawFunctionPatterns(BitBucket *modules, BitBucket *isFunction, uint8_t version, uint8_t ecc) {
+    
+    uint8_t size = modules->bitOffsetOrWidth;
+
+    // Draw the horizontal and vertical timing patterns
+    for (uint8_t i = 0; i < size; i++) {
+        setFunctionModule(modules, isFunction, 6, i, i % 2 == 0);
+        setFunctionModule(modules, isFunction, i, 6, i % 2 == 0);
+    }
+    
+    // Draw 3 finder patterns (all corners except bottom right; overwrites some timing modules)
+    drawFinderPattern(modules, isFunction, 3, 3);
+    drawFinderPattern(modules, isFunction, size - 4, 3);
+    drawFinderPattern(modules, isFunction, 3, size - 4);
+    
+#if LOCK_VERSION == 0 || LOCK_VERSION > 1
+
+    if (version > 1) {
+
+        // Draw the numerous alignment patterns
+        
+        uint8_t alignCount = version / 7 + 2;
+        uint8_t step;
+        if (version != 32) {
+            step = (version * 4 + alignCount * 2 + 1) / (2 * alignCount - 2) * 2;  // ceil((size - 13) / (2*numAlign - 2)) * 2
+        } else { // C-C-C-Combo breaker!
+            step = 26;
+        }
+        
+        uint8_t alignPositionIndex = alignCount - 1;
+        uint8_t alignPosition[alignCount];
+        
+        alignPosition[0] = 6;
+        
+        uint8_t size = version * 4 + 17;
+        for (uint8_t i = 0, pos = size - 7; i < alignCount - 1; i++, pos -= step) {
+            alignPosition[alignPositionIndex--] = pos;
+        }
+        
+        for (uint8_t i = 0; i < alignCount; i++) {
+            for (uint8_t j = 0; j < alignCount; j++) {
+                if ((i == 0 && j == 0) || (i == 0 && j == alignCount - 1) || (i == alignCount - 1 && j == 0)) {
+                    continue;  // Skip the three finder corners
+                } else {
+                    drawAlignmentPattern(modules, isFunction, alignPosition[i], alignPosition[j]);
+                }
+            }
+        }
+    }
+    
+#endif
+    
+    // Draw configuration data
+    drawFormatBits(modules, isFunction, ecc, 0);  // Dummy mask value; overwritten later in the constructor
+    drawVersion(modules, isFunction, version);
+}
+
+
+// Draws the given sequence of 8-bit codewords (data and error correction) onto the entire
+// data area of this QR Code symbol. Function modules need to be marked off before this is called.
+static void drawCodewords(BitBucket *modules, BitBucket *isFunction, BitBucket *codewords) {
+    
+    uint32_t bitLength = codewords->bitOffsetOrWidth;
+    uint8_t *data = codewords->data;
+    
+    uint8_t size = modules->bitOffsetOrWidth;
+    
+    // Bit index into the data
+    uint32_t i = 0;
+    
+    // Do the funny zigzag scan
+    for (int16_t right = size - 1; right >= 1; right -= 2) {  // Index of right column in each column pair
+        if (right == 6) { right = 5; }
+        
+        for (uint8_t vert = 0; vert < size; vert++) {  // Vertical counter
+            for (int j = 0; j < 2; j++) {
+                uint8_t x = right - j;  // Actual x coordinate
+                bool upwards = ((right & 2) == 0) ^ (x < 6);
+                uint8_t y = upwards ? size - 1 - vert : vert;  // Actual y coordinate
+                if (!bb_getBit(isFunction, x, y) && i < bitLength) {
+                    bb_setBit(modules, x, y, ((data[i >> 3] >> (7 - (i & 7))) & 1) != 0);
+                    i++;
+                }
+                // If there are any remainder bits (0 to 7), they are already
+                // set to 0/false/white when the grid of modules was initialized
+            }
+        }
+    }
+}
+
+
+
+#pragma mark - Penalty Calculation
+
+#define PENALTY_N1      3
+#define PENALTY_N2      3
+#define PENALTY_N3     40
+#define PENALTY_N4     10
+
+// Calculates and returns the penalty score based on state of this QR Code's current modules.
+// This is used by the automatic mask choice algorithm to find the mask pattern that yields the lowest score.
+// @TODO: This can be optimized by working with the bytes instead of bits.
+static uint32_t getPenaltyScore(BitBucket *modules) {
+    uint32_t result = 0;
+    
+    uint8_t size = modules->bitOffsetOrWidth;
+    
+    // Adjacent modules in row having same color
+    for (uint8_t y = 0; y < size; y++) {
+        
+        bool colorX = bb_getBit(modules, 0, y);
+        for (uint8_t x = 1, runX = 1; x < size; x++) {
+            bool cx = bb_getBit(modules, x, y);
+            if (cx != colorX) {
+                colorX = cx;
+                runX = 1;
+                
+            } else {
+                runX++;
+                if (runX == 5) {
+                    result += PENALTY_N1;
+                } else if (runX > 5) {
+                    result++;
+                }
+            }
+        }
+    }
+    
+    // Adjacent modules in column having same color
+    for (uint8_t x = 0; x < size; x++) {
+        bool colorY = bb_getBit(modules, x, 0);
+        for (uint8_t y = 1, runY = 1; y < size; y++) {
+            bool cy = bb_getBit(modules, x, y);
+            if (cy != colorY) {
+                colorY = cy;
+                runY = 1;
+            } else {
+                runY++;
+                if (runY == 5) {
+                    result += PENALTY_N1;
+                } else if (runY > 5) {
+                    result++;
+                }
+            }
+        }
+    }
+    
+    uint16_t black = 0;
+    for (uint8_t y = 0; y < size; y++) {
+        uint16_t bitsRow = 0, bitsCol = 0;
+        for (uint8_t x = 0; x < size; x++) {
+            bool color = bb_getBit(modules, x, y);
+
+            // 2*2 blocks of modules having same color
+            if (x > 0 && y > 0) {
+                bool colorUL = bb_getBit(modules, x - 1, y - 1);
+                bool colorUR = bb_getBit(modules, x, y - 1);
+                bool colorL = bb_getBit(modules, x - 1, y);
+                if (color == colorUL && color == colorUR && color == colorL) {
+                    result += PENALTY_N2;
+                }
+            }
+
+            // Finder-like pattern in rows and columns
+            bitsRow = ((bitsRow << 1) & 0x7FF) | color;
+            bitsCol = ((bitsCol << 1) & 0x7FF) | bb_getBit(modules, y, x);
+
+            // Needs 11 bits accumulated
+            if (x >= 10) {
+                if (bitsRow == 0x05D || bitsRow == 0x5D0) {
+                    result += PENALTY_N3;
+                }
+                if (bitsCol == 0x05D || bitsCol == 0x5D0) {
+                    result += PENALTY_N3;
+                }
+            }
+
+            // Balance of black and white modules
+            if (color) { black++; }
+        }
+    }
+
+    // Find smallest k such that (45-5k)% <= dark/total <= (55+5k)%
+    uint16_t total = size * size;
+    for (uint16_t k = 0; black * 20 < (9 - k) * total || black * 20 > (11 + k) * total; k++) {
+        result += PENALTY_N4;
+    }
+    
+    return result;
+}
+
+
+#pragma mark - Reed-Solomon Generator
+
+static uint8_t rs_multiply(uint8_t x, uint8_t y) {
+    // Russian peasant multiplication
+    // See: https://en.wikipedia.org/wiki/Ancient_Egyptian_multiplication
+    uint16_t z = 0;
+    for (int8_t i = 7; i >= 0; i--) {
+        z = (z << 1) ^ ((z >> 7) * 0x11D);
+        z ^= ((y >> i) & 1) * x;
+    }
+    return z;
+}
+
+static void rs_init(uint8_t degree, uint8_t *coeff) {
+    memset(coeff, 0, degree);
+    coeff[degree - 1] = 1;
+    
+    // Compute the product polynomial (x - r^0) * (x - r^1) * (x - r^2) * ... * (x - r^{degree-1}),
+    // drop the highest term, and store the rest of the coefficients in order of descending powers.
+    // Note that r = 0x02, which is a generator element of this field GF(2^8/0x11D).
+    uint16_t root = 1;
+    for (uint8_t i = 0; i < degree; i++) {
+        // Multiply the current product by (x - r^i)
+        for (uint8_t j = 0; j < degree; j++) {
+            coeff[j] = rs_multiply(coeff[j], root);
+            if (j + 1 < degree) {
+                coeff[j] ^= coeff[j + 1];
+            }
+        }
+        root = (root << 1) ^ ((root >> 7) * 0x11D);  // Multiply by 0x02 mod GF(2^8/0x11D)
+    }
+}
+
+static void rs_getRemainder(uint8_t degree, uint8_t *coeff, uint8_t *data, uint8_t length, uint8_t *result, uint8_t stride) {
+    // Compute the remainder by performing polynomial division
+    
+    //for (uint8_t i = 0; i < degree; i++) { result[] = 0; }
+    //memset(result, 0, degree);
+    
+    for (uint8_t i = 0; i < length; i++) {
+        uint8_t factor = data[i] ^ result[0];
+        for (uint8_t j = 1; j < degree; j++) {
+            result[(j - 1) * stride] = result[j * stride];
+        }
+        result[(degree - 1) * stride] = 0;
+        
+        for (uint8_t j = 0; j < degree; j++) {
+            result[j * stride] ^= rs_multiply(coeff[j], factor);
+        }
+    }
+}
+
+
+
+#pragma mark - QrCode
+
+static int8_t encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text, uint16_t length, uint8_t version) {
+    int8_t mode = MODE_BYTE;
+    
+    if (isNumeric((char*)text, length)) {
+        mode = MODE_NUMERIC;
+        bb_appendBits(dataCodewords, 1 << MODE_NUMERIC, 4);
+        bb_appendBits(dataCodewords, length, getModeBits(version, MODE_NUMERIC));
+
+        uint16_t accumData = 0;
+        uint8_t accumCount = 0;
+        for (uint16_t i = 0; i < length; i++) {
+            accumData = accumData * 10 + ((char)(text[i]) - '0');
+            accumCount++;
+            if (accumCount == 3) {
+                bb_appendBits(dataCodewords, accumData, 10);
+                accumData = 0;
+                accumCount = 0;
+            }
+        }
+        
+        // 1 or 2 digits remaining
+        if (accumCount > 0) {
+            bb_appendBits(dataCodewords, accumData, accumCount * 3 + 1);
+        }
+        
+    } else if (isAlphanumeric((char*)text, length)) {
+        mode = MODE_ALPHANUMERIC;
+        bb_appendBits(dataCodewords, 1 << MODE_ALPHANUMERIC, 4);
+        bb_appendBits(dataCodewords, length, getModeBits(version, MODE_ALPHANUMERIC));
+
+        uint16_t accumData = 0;
+        uint8_t accumCount = 0;
+        for (uint16_t i = 0; i  < length; i++) {
+            accumData = accumData * 45 + getAlphanumeric((char)(text[i]));
+            accumCount++;
+            if (accumCount == 2) {
+                bb_appendBits(dataCodewords, accumData, 11);
+                accumData = 0;
+                accumCount = 0;
+            }
+        }
+        
+        // 1 character remaining
+        if (accumCount > 0) {
+            bb_appendBits(dataCodewords, accumData, 6);
+        }
+        
+    } else {
+        bb_appendBits(dataCodewords, 1 << MODE_BYTE, 4);
+        bb_appendBits(dataCodewords, length, getModeBits(version, MODE_BYTE));
+        for (uint16_t i = 0; i < length; i++) {
+            bb_appendBits(dataCodewords, (char)(text[i]), 8);
+        }
+    }
+    
+    //bb_setBits(dataCodewords, length, 4, getModeBits(version, mode));
+    
+    return mode;
+}
+
+static void performErrorCorrection(uint8_t version, uint8_t ecc, BitBucket *data) {
+    
+    // See: http://www.thonky.com/qr-code-tutorial/structure-final-message
+    
+#if LOCK_VERSION == 0
+    uint8_t numBlocks = NUM_ERROR_CORRECTION_BLOCKS[ecc][version - 1];
+    uint16_t totalEcc = NUM_ERROR_CORRECTION_CODEWORDS[ecc][version - 1];
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES[version - 1];
+#else
+    uint8_t numBlocks = NUM_ERROR_CORRECTION_BLOCKS[ecc];
+    uint16_t totalEcc = NUM_ERROR_CORRECTION_CODEWORDS[ecc];
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES;
+#endif
+    
+    uint8_t blockEccLen = totalEcc / numBlocks;
+    uint8_t numShortBlocks = numBlocks - moduleCount / 8 % numBlocks;
+    uint8_t shortBlockLen = moduleCount / 8 / numBlocks;
+    
+    uint8_t shortDataBlockLen = shortBlockLen - blockEccLen;
+    
+    uint8_t result[data->capacityBytes];
+    memset(result, 0, sizeof(result));
+    
+    uint8_t coeff[blockEccLen];
+    rs_init(blockEccLen, coeff);
+    
+    uint16_t offset = 0;
+    uint8_t *dataBytes = data->data;
+    
+    
+    // Interleave all short blocks
+    for (uint8_t i = 0; i < shortDataBlockLen; i++) {
+        uint16_t index = i;
+        uint8_t stride = shortDataBlockLen;
+        for (uint8_t blockNum = 0; blockNum < numBlocks; blockNum++) {
+            result[offset++] = dataBytes[index];
+            
+#if LOCK_VERSION == 0 || LOCK_VERSION >= 5
+            if (blockNum == numShortBlocks) { stride++; }
+#endif
+            index += stride;
+        }
+    }
+    
+    // Version less than 5 only have short blocks
+#if LOCK_VERSION == 0 || LOCK_VERSION >= 5
+    {
+        // Interleave long blocks
+        uint16_t index = shortDataBlockLen * (numShortBlocks + 1);
+        uint8_t stride = shortDataBlockLen;
+        for (uint8_t blockNum = 0; blockNum < numBlocks - numShortBlocks; blockNum++) {
+            result[offset++] = dataBytes[index];
+            
+            if (blockNum == 0) { stride++; }
+            index += stride;
+        }
+    }
+#endif
+    
+    // Add all ecc blocks, interleaved
+    uint8_t blockSize = shortDataBlockLen;
+    for (uint8_t blockNum = 0; blockNum < numBlocks; blockNum++) {
+        
+#if LOCK_VERSION == 0 || LOCK_VERSION >= 5
+        if (blockNum == numShortBlocks) { blockSize++; }
+#endif
+        rs_getRemainder(blockEccLen, coeff, dataBytes, blockSize, &result[offset + blockNum], numBlocks);
+        dataBytes += blockSize;
+    }
+    
+    memcpy(data->data, result, data->capacityBytes);
+    data->bitOffsetOrWidth = moduleCount;
+}
+
+// We store the Format bits tightly packed into a single byte (each of the 4 modes is 2 bits)
+// The format bits can be determined by ECC_FORMAT_BITS >> (2 * ecc)
+static const uint8_t ECC_FORMAT_BITS = (0x02 << 6) | (0x03 << 4) | (0x00 << 2) | (0x01 << 0);
+
+
+#pragma mark - Public QRCode functions
+
+uint16_t qrcode_getBufferSize(uint8_t version) {
+    return bb_getGridSizeBytes(4 * version + 17);
+}
+
+// @TODO: Return error if data is too big.
+int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, uint8_t *data, uint16_t length) {
+    uint8_t size = version * 4 + 17;
+    qrcode->version = version;
+    qrcode->size = size;
+    qrcode->ecc = ecc;
+    qrcode->modules = modules;
+    
+    uint8_t eccFormatBits = (ECC_FORMAT_BITS >> (2 * ecc)) & 0x03;
+    
+#if LOCK_VERSION == 0
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES[version - 1];
+    uint16_t dataCapacity = moduleCount / 8 - NUM_ERROR_CORRECTION_CODEWORDS[eccFormatBits][version - 1];
+#else
+    version = LOCK_VERSION;
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES;
+    uint16_t dataCapacity = moduleCount / 8 - NUM_ERROR_CORRECTION_CODEWORDS[eccFormatBits];
+#endif
+    
+    struct BitBucket codewords;
+    uint8_t codewordBytes[bb_getBufferSizeBytes(moduleCount)];
+    bb_initBuffer(&codewords, codewordBytes, (int32_t)sizeof(codewordBytes));
+    
+    // Place the data code words into the buffer
+    int8_t mode = encodeDataCodewords(&codewords, data, length, version);
+    
+    if (mode < 0) { return -1; }
+    qrcode->mode = mode;
+    
+    // Add terminator and pad up to a byte if applicable
+    uint32_t padding = (dataCapacity * 8) - codewords.bitOffsetOrWidth;
+    if (padding > 4) { padding = 4; }
+    bb_appendBits(&codewords, 0, padding);
+    bb_appendBits(&codewords, 0, (8 - codewords.bitOffsetOrWidth % 8) % 8);
+
+    // Pad with alternate bytes until data capacity is reached
+    for (uint8_t padByte = 0xEC; codewords.bitOffsetOrWidth < (dataCapacity * 8); padByte ^= 0xEC ^ 0x11) {
+        bb_appendBits(&codewords, padByte, 8);
+    }
+
+    BitBucket modulesGrid;
+    bb_initGrid(&modulesGrid, modules, size);
+    
+    BitBucket isFunctionGrid;
+    uint8_t isFunctionGridBytes[bb_getGridSizeBytes(size)];
+    bb_initGrid(&isFunctionGrid, isFunctionGridBytes, size);
+    
+    // Draw function patterns, draw all codewords, do masking
+    drawFunctionPatterns(&modulesGrid, &isFunctionGrid, version, eccFormatBits);
+    performErrorCorrection(version, eccFormatBits, &codewords);
+    drawCodewords(&modulesGrid, &isFunctionGrid, &codewords);
+    
+    // Find the best (lowest penalty) mask
+    uint8_t mask = 0;
+    int32_t minPenalty = INT32_MAX;
+    for (uint8_t i = 0; i < 8; i++) {
+        drawFormatBits(&modulesGrid, &isFunctionGrid, eccFormatBits, i);
+        applyMask(&modulesGrid, &isFunctionGrid, i);
+        int penalty = getPenaltyScore(&modulesGrid);
+        if (penalty < minPenalty) {
+            mask = i;
+            minPenalty = penalty;
+        }
+        applyMask(&modulesGrid, &isFunctionGrid, i);  // Undoes the mask due to XOR
+    }
+    
+    qrcode->mask = mask;
+    
+    // Overwrite old format bits
+    drawFormatBits(&modulesGrid, &isFunctionGrid, eccFormatBits, mask);
+    
+    // Apply the final choice of mask
+    applyMask(&modulesGrid, &isFunctionGrid, mask);
+
+    return 0;
+}
+
+int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, const char *data) {
+    return qrcode_initBytes(qrcode, modules, version, ecc, (uint8_t*)data, strlen(data));
+}
+
+bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {
+    if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
+        return false;
+    }
+
+    uint32_t offset = y * qrcode->size + x;
+    return (qrcode->modules[offset >> 3] & (1 << (7 - (offset & 0x07)))) != 0;
+}
+
+/*
+uint8_t qrcode_getHexLength(QRCode *qrcode) {
+    return ((qrcode->size * qrcode->size) + 7) / 4;
+}
+
+void qrcode_getHex(QRCode *qrcode, char *result) {
+    
+}
+*/

--- a/src/qrcode.h
+++ b/src/qrcode.h
@@ -1,0 +1,99 @@
+/**
+ * The MIT License (MIT)
+ *
+ * This library is written and maintained by Richard Moore.
+ * Major parts were derived from Project Nayuki's library.
+ *
+ * Copyright (c) 2017 Richard Moore     (https://github.com/ricmoo/QRCode)
+ * Copyright (c) 2017 Project Nayuki    (https://www.nayuki.io/page/qr-code-generator-library)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ *  Special thanks to Nayuki (https://www.nayuki.io/) from which this library was
+ *  heavily inspired and compared against.
+ *
+ *  See: https://github.com/nayuki/QR-Code-generator/tree/master/cpp
+ */
+
+
+#ifndef __QRCODE_H_
+#define __QRCODE_H_
+
+#ifndef __cplusplus
+typedef unsigned char bool;
+static const bool false = 0;
+static const bool true = 1;
+#endif
+
+#include <stdint.h>
+
+
+// QR Code Format Encoding
+#define MODE_NUMERIC        0
+#define MODE_ALPHANUMERIC   1
+#define MODE_BYTE           2
+
+
+// Error Correction Code Levels
+#define ECC_LOW            0
+#define ECC_MEDIUM         1
+#define ECC_QUARTILE       2
+#define ECC_HIGH           3
+
+
+// If set to non-zero, this library can ONLY produce QR codes at that version
+// This saves a lot of dynamic memory, as the codeword tables are skipped
+#ifndef LOCK_VERSION
+#define LOCK_VERSION       0
+#endif
+
+
+typedef struct QRCode {
+    uint8_t version;
+    uint8_t size;
+    uint8_t ecc;
+    uint8_t mode;
+    uint8_t mask;
+    uint8_t *modules;
+} QRCode;
+
+
+#ifdef __cplusplus
+extern "C"{
+#endif  /* __cplusplus */
+
+
+
+uint16_t qrcode_getBufferSize(uint8_t version);
+
+int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, const char *data);
+int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, uint8_t *data, uint16_t length);
+
+bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y);
+
+
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */
+
+
+#endif  /* __QRCODE_H_ */

--- a/src/raw/detector.cpp
+++ b/src/raw/detector.cpp
@@ -17,12 +17,17 @@
 // ================================
 // Pin and Buzzer Definitions - Xiao ESP32 S3
 // ================================
-#define BUZZER_PIN 3   // GPIO3 (D2) for buzzer - good PWM pin on Xiao ESP32 S3
 #define BUZZER_FREQ 2000  // Frequency in Hz
 #define BUZZER_DUTY 127  // 50% duty cycle for good volume without excessive power draw
 #define BEEP_DURATION 200  // Duration of each beep in ms
 #define BEEP_PAUSE 50  // Pause between beeps in ms (faster sequence)
 #define LED_PIN 21   // GPIO21 for onboard LED (inverted logic)
+
+// Buzzer pin routing: GPIO3 (D2) for the external oui-spy piezo, or GPIO4
+// (D3/A3) for the expansion board's passive buzzer when the chassis is present.
+// Set in setup() after dashboard_init().
+static int buzzerPin = BUZZER_PIN_EXTERNAL;
+#define BUZZER_PIN buzzerPin
 
 // ================================
 // NeoPixel Definitions - Xiao ESP32 S3
@@ -2509,8 +2514,10 @@ void setup() {
     Serial.println("\n");
     
     // Probe for the expansion board OLED. Pins 5/6 are free in this mode, so
-    // this is safe and a no-op when no display is attached.
+    // this is safe and a no-op when no display is attached. Also route the
+    // buzzer to the chassis buzzer (GPIO4) when the expansion board is present.
     dashboard_init();
+    buzzerPin = dashboard_buzzer_pin();
     if (dashboard_present()) {
         dashboard_clear();
         dashRow(0);
@@ -2567,13 +2574,17 @@ void setup() {
     singleBeep();
     delay(500);
     
-    initializeNeoPixel();
-    
-    // Test NeoPixel
-    setNeoPixelColor(255, 0, 255); // Bright pink
-    delay(1000);
-    setNeoPixelColor(128, 0, 255); // Purple
-    delay(1000);
+    // NeoPixel shares GPIO4 with the expansion board's buzzer, so it is skipped
+    // when the chassis (and its buzzer) is present.
+    if (!dashboard_present()) {
+        initializeNeoPixel();
+        
+        // Test NeoPixel
+        setNeoPixelColor(255, 0, 255); // Bright pink
+        delay(1000);
+        setNeoPixelColor(128, 0, 255); // Purple
+        delay(1000);
+    }
     
     // Check for factory reset flag first
     preferences.begin("ouispy", true); // read-only
@@ -2748,8 +2759,8 @@ void loop() {
         }
     }
     
-    // Update NeoPixel animation
-    updateNeoPixelAnimation();
+    // Update NeoPixel animation (skipped when the expansion board buzzer owns GPIO4)
+    if (!dashboard_present()) updateNeoPixelAnimation();
     
     delay(100);
 } 

--- a/src/raw/detector.cpp
+++ b/src/raw/detector.cpp
@@ -2305,6 +2305,184 @@ void startScanningMode() {
 
 
 // ================================
+// Expansion Board OLED Dashboard
+// ================================
+#define DASH_REFRESH_MS 1000
+#define DASH_BASELINE 6
+#define DASH_ROW_STEP 8
+
+static unsigned long lastDashboardRefresh = 0;
+
+enum DashPage {
+    DASH_PAGE_SUMMARY = 0,
+    DASH_PAGE_LATEST,
+    DASH_PAGE_FLEET,
+    DASH_PAGE_FILTERS,
+    DASH_PAGE_COUNT
+};
+static uint8_t dashPage = DASH_PAGE_SUMMARY;
+
+static void dashRow(uint8_t row) {
+    dashboard_set_cursor(0, DASH_BASELINE + row * DASH_ROW_STEP);
+}
+
+static void dashFooter(unsigned long now) {
+    dashRow(7);
+    dashboard_printf("P%u/%u UP %02lu:%02lu:%02lu",
+                     (unsigned)(dashPage + 1), (unsigned)DASH_PAGE_COUNT,
+                     (unsigned long)((now / 3600000UL) % 100UL),
+                     (unsigned long)((now / 60000UL) % 60UL),
+                     (unsigned long)((now / 1000UL) % 60UL));
+}
+
+static void dashPageSummary(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("DETECTOR FLT:%u DEV:%u",
+                     (unsigned)targetFilters.size(), (unsigned)devices.size());
+    dashboard_draw_hline(0, 7, 128);
+
+    if (currentMode == SCANNING_MODE) {
+        dashRow(2);
+        dashboard_printf("MODE SCANNING");
+        dashRow(3);
+        dashboard_printf("WATCHLIST ACTIVE");
+    } else {
+        dashRow(2);
+        dashboard_printf("MODE CONFIG");
+        dashRow(3);
+        dashboard_printf("WAITING FOR CONFIG");
+    }
+    dashRow(4);
+    dashboard_printf("BZ:%s LED:%s", buzzerEnabled ? "ON" : "OFF",
+                     ledEnabled ? "ON" : "OFF");
+    dashRow(5);
+    dashboard_printf(currentMode == CONFIG_MODE ? "AP %s" : "WIFI OFF",
+                     currentMode == CONFIG_MODE ? AP_SSID.c_str() : "");
+    dashFooter(now);
+}
+
+static void dashPageLatest(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("LATEST DETECTION");
+    dashboard_draw_hline(0, 7, 128);
+
+    if (devices.size() == 0) {
+        dashRow(3);
+        dashboard_printf("NO DEVICES YET");
+        dashRow(4);
+        dashboard_printf("CONFIG VIA WEB UI");
+        dashFooter(now);
+        return;
+    }
+
+    const DeviceInfo* latest = &devices[0];
+    unsigned long newest = devices[0].lastSeen;
+    for (size_t i = 1; i < devices.size(); i++) {
+        if (devices[i].lastSeen > newest) {
+            newest = devices[i].lastSeen;
+            latest = &devices[i];
+        }
+    }
+
+    dashRow(2);
+    dashboard_printf("%s", latest->macAddress.c_str());
+    String alias = getDeviceAlias(latest->macAddress);
+    if (alias.length() > 0) {
+        dashRow(3);
+        dashboard_printf("ALIAS %s", alias.c_str());
+    }
+    dashRow(4);
+    dashboard_printf("RSSI %d dBm", latest->rssi);
+    dashRow(5);
+    dashboard_printf("%.14s", latest->filterDescription.c_str());
+    dashRow(6);
+    dashboard_printf("SEEN %lus AGO",
+                     (unsigned long)((now - latest->lastSeen) / 1000UL));
+    dashFooter(now);
+}
+
+static void dashPageFleet(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("DEVICES RSSI TOT:%u", (unsigned)devices.size());
+    dashboard_draw_hline(0, 7, 128);
+
+    if (devices.size() == 0) {
+        dashRow(3);
+        dashboard_printf("NO DETECTIONS YET");
+        dashFooter(now);
+        return;
+    }
+
+    std::vector<const DeviceInfo*> sorted;
+    sorted.reserve(devices.size());
+    for (const auto& d : devices) sorted.push_back(&d);
+    std::sort(sorted.begin(), sorted.end(),
+              [](const DeviceInfo* a, const DeviceInfo* b) { return a->rssi > b->rssi; });
+
+    size_t shown = 0;
+    for (const DeviceInfo* d : sorted) {
+        if (shown >= 5) break;
+        dashRow(2 + shown);
+        dashboard_printf("%d %s %d", (int)shown + 1,
+                         d->macAddress.c_str(), d->rssi);
+        shown++;
+    }
+    if (devices.size() > 5) {
+        dashRow(6);
+        dashboard_printf("...and %u more", (unsigned)(devices.size() - 5));
+    }
+    dashFooter(now);
+}
+
+static void dashPageFilters(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("WATCHLIST FLT:%u", (unsigned)targetFilters.size());
+    dashboard_draw_hline(0, 7, 128);
+
+    if (targetFilters.size() == 0) {
+        dashRow(3);
+        dashboard_printf("NO FILTERS");
+        dashRow(4);
+        dashboard_printf("CONFIGURE VIA WEB UI");
+        dashFooter(now);
+        return;
+    }
+
+    size_t shown = 0;
+    for (const auto& f : targetFilters) {
+        if (shown >= 5) break;
+        const char* type = f.isFullMAC ? "M" : "O";
+        dashRow(2 + shown);
+        dashboard_printf("%d %s %.12s", (int)shown + 1, type,
+                         f.identifier.c_str());
+        shown++;
+    }
+    if (targetFilters.size() > 5) {
+        dashRow(6);
+        dashboard_printf("...and %u more", (unsigned)(targetFilters.size() - 5));
+    }
+    dashFooter(now);
+}
+
+void renderDashboard() {
+    if (!dashboard_present()) return;
+
+    unsigned long now = millis();
+    if (now - lastDashboardRefresh < DASH_REFRESH_MS) return;
+    lastDashboardRefresh = now;
+
+    dashboard_clear();
+    switch (dashPage) {
+        case DASH_PAGE_SUMMARY: dashPageSummary(now); break;
+        case DASH_PAGE_LATEST:  dashPageLatest(now); break;
+        case DASH_PAGE_FLEET:   dashPageFleet(now); break;
+        case DASH_PAGE_FILTERS: dashPageFilters(now); break;
+        default:                dashPage = DASH_PAGE_SUMMARY; break;
+    }
+    dashboard_flush();
+}
+
+// ================================
 // Setup Function
 // ================================
 void setup() {
@@ -2329,6 +2507,23 @@ void setup() {
     Serial.println(" \\____/|____/|__|         /____  >|   __// ____| \\____ |\\___  >__|  \\___  >\\___  >__|  \\____/|__|   ");
     Serial.println("                               \\/ |__|   \\/           \\/    \\/          \\/     \\/                   ");
     Serial.println("\n");
+    
+    // Probe for the expansion board OLED. Pins 5/6 are free in this mode, so
+    // this is safe and a no-op when no display is attached.
+    dashboard_init();
+    if (dashboard_present()) {
+        dashboard_clear();
+        dashRow(0);
+        dashboard_printf("DETECTOR");
+        dashRow(1);
+        dashboard_printf("BLE WATCHLIST ALERT");
+        dashRow(2);
+        dashboard_printf("MODE 1");
+        dashRow(5);
+        dashboard_printf("BOOTING...");
+        dashboard_flush();
+        delay(1200);
+    }
     
     // Randomize MAC address on each boot
     uint8_t newMAC[6];
@@ -2436,6 +2631,14 @@ void loop() {
     static unsigned long lastCleanupTime = 0;
     static unsigned long lastStatusTime = 0;
     unsigned long currentMillis = millis();
+    
+    // Expansion board button advances the dashboard page (display only)
+    if (dashboard_present() && dashboard_button_pressed()) {
+        dashPage++;
+        if (dashPage >= DASH_PAGE_COUNT) dashPage = 0;
+        lastDashboardRefresh = 0;  // redraw immediately on page change
+    }
+    renderDashboard();
     
     if (currentMode == CONFIG_MODE) {
         // Check for scheduled normal restart (from burn-in config)

--- a/src/raw/detector.cpp
+++ b/src/raw/detector.cpp
@@ -2323,6 +2323,7 @@ enum DashPage {
     DASH_PAGE_LATEST,
     DASH_PAGE_FLEET,
     DASH_PAGE_FILTERS,
+    DASH_PAGE_QR,
     DASH_PAGE_COUNT
 };
 static uint8_t dashPage = DASH_PAGE_SUMMARY;
@@ -2363,6 +2364,10 @@ static void dashPageSummary(unsigned long now) {
     dashRow(5);
     dashboard_printf(currentMode == CONFIG_MODE ? "AP %s" : "WIFI OFF",
                      currentMode == CONFIG_MODE ? AP_SSID.c_str() : "");
+    if (currentMode == CONFIG_MODE) {
+        dashRow(6);
+        dashboard_printf("WEB 192.168.4.1");
+    }
     dashFooter(now);
 }
 
@@ -2469,6 +2474,19 @@ static void dashPageFilters(unsigned long now) {
     dashFooter(now);
 }
 
+static void dashPageQR(unsigned long now) {
+    char wifiStr[96];
+    snprintf(wifiStr, sizeof(wifiStr), "WIFI:T:WPA;S:%s;P:%s;;",
+             AP_SSID.c_str(), AP_PASSWORD.c_str());
+    if (!dashboard_draw_qrcode(wifiStr)) {
+        dashRow(2);
+        dashboard_printf("SSID/PASS TOO LONG");
+        dashRow(3);
+        dashboard_printf("FOR QR CODE");
+        dashFooter(now);
+    }
+}
+
 void renderDashboard() {
     if (!dashboard_present()) return;
 
@@ -2482,6 +2500,7 @@ void renderDashboard() {
         case DASH_PAGE_LATEST:  dashPageLatest(now); break;
         case DASH_PAGE_FLEET:   dashPageFleet(now); break;
         case DASH_PAGE_FILTERS: dashPageFilters(now); break;
+        case DASH_PAGE_QR:      dashPageQR(now); break;
         default:                dashPage = DASH_PAGE_SUMMARY; break;
     }
     dashboard_flush();

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -151,7 +151,6 @@ static Adafruit_NeoPixel fyPixel(1, FY_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
 static bool fyPixelAlertMode = false;
 static unsigned long fyPixelAlertStart = 0;
 static unsigned long fyLastBleScan = 0;
-static bool fyTriggered = false;
 static bool fyDeviceInRange = false;
 static unsigned long fyLastDetTime = 0;
 static unsigned long fyLastHB = 0;
@@ -610,9 +609,8 @@ class FYBLECallbacks : public NimBLEAdvertisedDeviceCallbacks {
                        method, addrStr.c_str(), name.c_str(), rssi, gpsBuf);
             }
 
-            if (!fyTriggered) {
-                fyTriggered = true;
-                fyDetectBeep();
+            if (idx >= 0 && fyDet[idx].count == 1) {
+                fyDetectBeep();  // Flash + sound on every NEW device
             }
             fyDeviceInRange = true;
             fyLastDetTime = millis();
@@ -1090,7 +1088,6 @@ static void fySetupServer() {
         if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(200)) == pdTRUE) {
             fyDetCount = 0;
             memset(fyDet, 0, sizeof(fyDet));
-            fyTriggered = false;
             fyDeviceInRange = false;
             xSemaphoreGive(fyMutex);
         }
@@ -1209,7 +1206,6 @@ void loop() {
         if (millis() - fyLastDetTime >= 30000) {
             printf("[FLOCK-YOU] Device out of range - stopping heartbeat\n");
             fyDeviceInRange = false;
-            fyTriggered = false;
         }
     }
 

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -287,18 +287,14 @@ static uint32_t fyHsvToRgb(uint16_t h, uint8_t s, uint8_t v) {
 // Idle: slow purple breathing (hue 270)
 static void fyPixelBreathing() {
     static unsigned long lastUpdate = 0;
-    static float brightness = 0.0;
-    static bool increasing = true;
     if (millis() - lastUpdate < 20) return;
     lastUpdate = millis();
-    if (increasing) {
-        brightness += 0.02;
-        if (brightness >= 1.0) { brightness = 1.0; increasing = false; }
-    } else {
-        brightness -= 0.02;
-        if (brightness <= 0.1) { brightness = 0.1; increasing = true; }
-    }
-    uint32_t color = fyHsvToRgb(270, 255, (uint8_t)(FY_NEOPIXEL_BRIGHTNESS * brightness));
+    // Time-based sine wave: smooth regardless of loop speed
+    // 1500ms full cycle (~0.67Hz breathing rate)
+    float phase = (millis() % 1500) / 1500.0f * 2.0f * 3.14159f;
+    float val = (sinf(phase) + 1.0f) / 2.0f;  // 0.0 – 1.0
+    uint8_t v = 15 + (uint8_t)(val * 45);      // 15 – 60 range
+    uint32_t color = fyHsvToRgb(270, 255, v);
     fyPixel.setPixelColor(0, color);
     fyPixel.show();
 }

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -32,7 +32,11 @@
 // CONFIGURATION
 // ============================================================================
 
-#define BUZZER_PIN 3
+// Buzzer pin routing: GPIO3 (D2) for the external oui-spy piezo, or GPIO4
+// (D3/A3) for the expansion board's passive buzzer when the chassis is present.
+// Set in setup() after dashboard_init().
+static int buzzerPin = BUZZER_PIN_EXTERNAL;
+#define BUZZER_PIN buzzerPin
 
 // Hardware GPS (Seeed L76K GNSS module)
 #define GPS_RX_PIN 44      // D7 — ESP32 RX <- GPS TX
@@ -1302,8 +1306,10 @@ void setup() {
 
     // Probe for the expansion board OLED. Pins 5/6 are free in this mode
     // (the hardware GPS uses 44/43), so this is safe and a no-op when no
-    // display is attached.
+    // display is attached. Also route the buzzer to the chassis buzzer
+    // (GPIO4) when the expansion board is present.
     dashboard_init();
+    buzzerPin = dashboard_buzzer_pin();
     if (dashboard_present()) {
         dashboard_clear();
         dashRow(0);
@@ -1327,20 +1333,24 @@ void setup() {
     pinMode(BUZZER_PIN, OUTPUT);
     digitalWrite(BUZZER_PIN, LOW);
 
-    // Init NeoPixel
-    fyPixel.begin();
-    fyPixel.setBrightness(FY_NEOPIXEL_BRIGHTNESS);
-    fyPixel.clear();
-    fyPixel.show();
-    // Test flash: pink -> purple
-    fyPixel.setPixelColor(0, fyPixel.Color(236, 72, 153));  // pink #ec4899
-    fyPixel.show();
-    delay(500);
-    fyPixel.setPixelColor(0, fyPixel.Color(139, 92, 246));  // purple #8b5cf6
-    fyPixel.show();
-    delay(500);
-    fyPixel.clear();
-    fyPixel.show();
+    // NeoPixel shares GPIO4 with the expansion board's buzzer, so it is skipped
+    // when the chassis (and its buzzer) is present.
+    if (!dashboard_present()) {
+        // Init NeoPixel
+        fyPixel.begin();
+        fyPixel.setBrightness(FY_NEOPIXEL_BRIGHTNESS);
+        fyPixel.clear();
+        fyPixel.show();
+        // Test flash: pink -> purple
+        fyPixel.setPixelColor(0, fyPixel.Color(236, 72, 153));  // pink #ec4899
+        fyPixel.show();
+        delay(500);
+        fyPixel.setPixelColor(0, fyPixel.Color(139, 92, 246));  // purple #8b5cf6
+        fyPixel.show();
+        delay(500);
+        fyPixel.clear();
+        fyPixel.show();
+    }
 
     fyMutex = xSemaphoreCreateMutex();
 
@@ -1404,7 +1414,8 @@ void loop() {
     renderDashboard();
 
     fyProcessHardwareGPS();
-    fyUpdatePixel();
+    // NeoPixel skipped when the expansion board buzzer owns GPIO4
+    if (!dashboard_present()) fyUpdatePixel();
 
     // BLE scanning cycle
     if (millis() - fyLastBleScan >= BLE_SCAN_INTERVAL && !fyBLEScan->isScanning()) {

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -1118,6 +1118,7 @@ enum DashPage {
     DASH_PAGE_LATEST,
     DASH_PAGE_FLEET,
     DASH_PAGE_GPS,
+    DASH_PAGE_QR,
     DASH_PAGE_COUNT
 };
 static uint8_t dashPage = DASH_PAGE_SUMMARY;
@@ -1278,6 +1279,19 @@ static void dashPageGPS(unsigned long now) {
     dashFooter(now);
 }
 
+static void dashPageQR(unsigned long now) {
+    char wifiStr[96];
+    snprintf(wifiStr, sizeof(wifiStr), "WIFI:T:WPA;S:%s;P:%s;;",
+             FY_AP_SSID, FY_AP_PASS);
+    if (!dashboard_draw_qrcode(wifiStr)) {
+        dashRow(2);
+        dashboard_printf("SSID/PASS TOO LONG");
+        dashRow(3);
+        dashboard_printf("FOR QR CODE");
+        dashFooter(now);
+    }
+}
+
 static void renderDashboard() {
     if (!dashboard_present()) return;
 
@@ -1291,6 +1305,7 @@ static void renderDashboard() {
         case DASH_PAGE_LATEST:  dashPageLatest(now); break;
         case DASH_PAGE_FLEET:   dashPageFleet(now); break;
         case DASH_PAGE_GPS:     dashPageGPS(now); break;
+        case DASH_PAGE_QR:      dashPageQR(now); break;
         default:                dashPage = DASH_PAGE_SUMMARY; break;
     }
     dashboard_flush();

--- a/src/raw/flockyou.cpp
+++ b/src/raw/flockyou.cpp
@@ -1100,12 +1100,223 @@ static void fySetupServer() {
 }
 
 // ============================================================================
+// EXPANSION BOARD OLED DASHBOARD
+// ============================================================================
+
+#define DASH_REFRESH_MS 1000
+#define DASH_BASELINE 6
+#define DASH_ROW_STEP 8
+
+static unsigned long lastDashboardRefresh = 0;
+
+enum DashPage {
+    DASH_PAGE_SUMMARY = 0,
+    DASH_PAGE_LATEST,
+    DASH_PAGE_FLEET,
+    DASH_PAGE_GPS,
+    DASH_PAGE_COUNT
+};
+static uint8_t dashPage = DASH_PAGE_SUMMARY;
+
+static void dashRow(uint8_t row) {
+    dashboard_set_cursor(0, DASH_BASELINE + row * DASH_ROW_STEP);
+}
+
+static void dashFooter(unsigned long now) {
+    dashRow(7);
+    dashboard_printf("P%u/%u UP %02lu:%02lu:%02lu",
+                     (unsigned)(dashPage + 1), (unsigned)DASH_PAGE_COUNT,
+                     (unsigned long)((now / 3600000UL) % 100UL),
+                     (unsigned long)((now / 60000UL) % 60UL),
+                     (unsigned long)((now / 1000UL) % 60UL));
+}
+
+static void dashPageSummary(unsigned long now) {
+    int ravens = 0;
+    if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        for (int i = 0; i < fyDetCount; i++) {
+            if (fyDet[i].isRaven) ravens++;
+        }
+        xSemaphoreGive(fyMutex);
+    }
+
+    dashRow(0);
+    dashboard_printf("FLOCK-YOU DEV:%d", fyDetCount);
+    dashboard_draw_hline(0, 7, 128);
+
+    dashRow(2);
+    dashboard_printf(fyDeviceInRange ? "DEVICE IN RANGE" : "NO DEVICE IN RANGE");
+    dashRow(3);
+    dashboard_printf("RAVEN:%d BUZZ:%s", ravens, fyBuzzerOn ? "ON" : "OFF");
+    dashRow(4);
+    dashboard_printf("BLE+AP SCANNING");
+    dashRow(5);
+    dashboard_printf("WEB 192.168.4.1");
+    dashFooter(now);
+}
+
+static void dashPageLatest(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("LATEST DETECTION");
+    dashboard_draw_hline(0, 7, 128);
+
+    if (fyDetCount == 0) {
+        dashRow(3);
+        dashboard_printf("NO DETECTIONS");
+        dashRow(4);
+        dashboard_printf("SCANNING FOR DEVICES");
+        dashFooter(now);
+        return;
+    }
+
+    char mac[18] = "";
+    char method[24] = "";
+    int rssi = 0;
+    unsigned long last = 0;
+    int count = 0;
+    if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        int best = 0;
+        for (int i = 1; i < fyDetCount; i++) {
+            if (fyDet[i].lastSeen > fyDet[best].lastSeen) best = i;
+        }
+        strncpy(mac, fyDet[best].mac, sizeof(mac) - 1);
+        strncpy(method, fyDet[best].method, sizeof(method) - 1);
+        rssi = fyDet[best].rssi;
+        last = fyDet[best].lastSeen;
+        count = fyDet[best].count;
+        xSemaphoreGive(fyMutex);
+    }
+
+    dashRow(2);
+    dashboard_printf("%s", mac);
+    dashRow(3);
+    dashboard_printf("RSSI %d dBm x%d", rssi, count);
+    dashRow(4);
+    dashboard_printf("%.14s", method);
+    dashRow(5);
+    dashboard_printf("SEEN %lus AGO", (unsigned long)((now - last) / 1000UL));
+    dashFooter(now);
+}
+
+static void dashPageFleet(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("FLEET TOT:%d", fyDetCount);
+    dashboard_draw_hline(0, 7, 128);
+
+    if (fyDetCount == 0) {
+        dashRow(3);
+        dashboard_printf("NO DETECTIONS");
+        dashFooter(now);
+        return;
+    }
+
+    static const int MAX_SHOW = 5;
+    char macs[MAX_SHOW][18];
+    int rssis[MAX_SHOW];
+    int nshown = 0;
+
+    if (fyMutex && xSemaphoreTake(fyMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        bool used[MAX_DETECTIONS];
+        memset(used, 0, sizeof(used));
+        for (int s = 0; s < MAX_SHOW; s++) {
+            int best = -1;
+            for (int i = 0; i < fyDetCount; i++) {
+                if (used[i]) continue;
+                if (best < 0 || fyDet[i].rssi > fyDet[best].rssi) best = i;
+            }
+            if (best < 0) break;
+            used[best] = true;
+            strncpy(macs[nshown], fyDet[best].mac, 17);
+            macs[nshown][17] = '\0';
+            rssis[nshown] = fyDet[best].rssi;
+            nshown++;
+        }
+        xSemaphoreGive(fyMutex);
+    }
+
+    for (int i = 0; i < nshown; i++) {
+        dashRow(2 + i);
+        dashboard_printf("%d %s %d", i + 1, macs[i], rssis[i]);
+    }
+    if (fyDetCount > MAX_SHOW) {
+        dashRow(6);
+        dashboard_printf("...and %d more", fyDetCount - MAX_SHOW);
+    }
+    dashFooter(now);
+}
+
+static void dashPageGPS(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("GPS STATUS");
+    dashboard_draw_hline(0, 7, 128);
+
+    const char* src = "NONE";
+    if (fyGPSIsHardware && fyHWGPSFix) src = "HARDWARE";
+    else if (fyGPSIsFresh()) src = "PHONE";
+
+    dashRow(2);
+    dashboard_printf("SOURCE %s", src);
+    if (fyGPSIsHardware) {
+        dashRow(3);
+        dashboard_printf("SATS %d", fyHWGPSSats);
+    }
+    if (fyGPSIsFresh()) {
+        dashRow(4);
+        dashboard_printf("LAT %.5f", fyGPSLat);
+        dashRow(5);
+        dashboard_printf("LON %.5f", fyGPSLon);
+        dashRow(6);
+        dashboard_printf("ACC %.1fm", fyGPSAcc);
+    } else {
+        dashRow(4);
+        dashboard_printf("NO FIX YET");
+    }
+    dashFooter(now);
+}
+
+static void renderDashboard() {
+    if (!dashboard_present()) return;
+
+    unsigned long now = millis();
+    if (now - lastDashboardRefresh < DASH_REFRESH_MS) return;
+    lastDashboardRefresh = now;
+
+    dashboard_clear();
+    switch (dashPage) {
+        case DASH_PAGE_SUMMARY: dashPageSummary(now); break;
+        case DASH_PAGE_LATEST:  dashPageLatest(now); break;
+        case DASH_PAGE_FLEET:   dashPageFleet(now); break;
+        case DASH_PAGE_GPS:     dashPageGPS(now); break;
+        default:                dashPage = DASH_PAGE_SUMMARY; break;
+    }
+    dashboard_flush();
+}
+
+// ============================================================================
 // MAIN FUNCTIONS
 // ============================================================================
 
 void setup() {
     Serial.begin(115200);
     delay(500);
+
+    // Probe for the expansion board OLED. Pins 5/6 are free in this mode
+    // (the hardware GPS uses 44/43), so this is safe and a no-op when no
+    // display is attached.
+    dashboard_init();
+    if (dashboard_present()) {
+        dashboard_clear();
+        dashRow(0);
+        dashboard_printf("FLOCK-YOU");
+        dashRow(1);
+        dashboard_printf("SURVEILLANCE DETECTOR");
+        dashRow(2);
+        dashboard_printf("MODE 4");
+        dashRow(5);
+        dashboard_printf("BOOTING...");
+        dashboard_flush();
+        delay(1200);
+    }
 
     // Read buzzer setting from OUI-SPY NVS
     Preferences bzP;
@@ -1184,6 +1395,14 @@ void setup() {
 }
 
 void loop() {
+    // Expansion board button advances the dashboard page (display only)
+    if (dashboard_present() && dashboard_button_pressed()) {
+        dashPage++;
+        if (dashPage >= DASH_PAGE_COUNT) dashPage = 0;
+        lastDashboardRefresh = 0;  // redraw immediately on page change
+    }
+    renderDashboard();
+
     fyProcessHardwareGPS();
     fyUpdatePixel();
 

--- a/src/raw/foxhunter.cpp
+++ b/src/raw/foxhunter.cpp
@@ -8,10 +8,15 @@
 #include <esp_wifi.h>
 
 // Hardware configuration
-#define BUZZER_PIN 3
 #define BUZZER_FREQ 2000
 #define BUZZER_DUTY 127
 #define LED_PIN 21
+
+// Buzzer pin routing: GPIO3 (D2) for the external oui-spy piezo, or GPIO4
+// (D3/A3) for the expansion board's passive buzzer when the chassis is present.
+// Set in setup() after dashboard_init().
+static int buzzerPin = BUZZER_PIN_EXTERNAL;
+#define BUZZER_PIN buzzerPin
 
 // Network configuration
 const char* AP_SSID = "foxhunter";
@@ -1075,8 +1080,10 @@ void setup() {
     Serial.println("Initializing...\n");
     
     // Probe for the expansion board OLED. Pins 5/6 are free in this mode, so
-    // this is safe and a no-op when no display is attached.
+    // this is safe and a no-op when no display is attached. Also route the
+    // buzzer to the chassis buzzer (GPIO4) when the expansion board is present.
     dashboard_init();
+    buzzerPin = dashboard_buzzer_pin();
     if (dashboard_present()) {
         dashboard_clear();
         dashRow(0);

--- a/src/raw/foxhunter.cpp
+++ b/src/raw/foxhunter.cpp
@@ -930,6 +930,140 @@ void startTrackingMode() {
     ascendingBeeps();
 }
 
+// ================================
+// Expansion Board OLED Dashboard
+// ================================
+#define DASH_REFRESH_MS 500
+#define DASH_BASELINE 6
+#define DASH_ROW_STEP 8
+
+static unsigned long lastDashboardRefresh = 0;
+
+enum DashPage {
+    DASH_PAGE_SUMMARY = 0,
+    DASH_PAGE_SIGNAL,
+    DASH_PAGE_TARGET,
+    DASH_PAGE_COUNT
+};
+static uint8_t dashPage = DASH_PAGE_SUMMARY;
+
+static void dashRow(uint8_t row) {
+    dashboard_set_cursor(0, DASH_BASELINE + row * DASH_ROW_STEP);
+}
+
+static void dashFooter(unsigned long now) {
+    dashRow(7);
+    dashboard_printf("P%u/%u UP %02lu:%02lu:%02lu",
+                     (unsigned)(dashPage + 1), (unsigned)DASH_PAGE_COUNT,
+                     (unsigned long)((now / 3600000UL) % 100UL),
+                     (unsigned long)((now / 60000UL) % 60UL),
+                     (unsigned long)((now / 1000UL) % 60UL));
+}
+
+static void dashPageSummary(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("FOXHUNTER %s",
+                     currentMode == TRACKING_MODE ? "TRACK" : "CONFIG");
+    dashboard_draw_hline(0, 7, 128);
+
+    if (currentMode == TRACKING_MODE) {
+        dashRow(2);
+        dashboard_printf("TARGET %s", targetMAC.length() > 0 ? "SET" : "NONE");
+        dashRow(3);
+        dashboard_printf(targetDetected ? "SIGNAL ACQUIRED" : "SEARCHING...");
+        dashRow(4);
+        dashboard_printf("RSSI %d dBm", currentRSSI);
+        dashRow(5);
+        dashboard_printf("BZ:%s LED:%s", buzzerEnabled ? "ON" : "OFF",
+                         ledEnabled ? "ON" : "OFF");
+    } else {
+        dashRow(2);
+        dashboard_printf("TARGET %s", targetMAC.length() > 0 ? "SET" : "NONE");
+        dashRow(3);
+        dashboard_printf("AP foxhunter");
+        dashRow(4);
+        dashboard_printf("192.168.4.1 CONFIG");
+    }
+    dashFooter(now);
+}
+
+static void dashPageSignal(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("SIGNAL STRENGTH");
+    dashboard_draw_hline(0, 7, 128);
+
+    if (currentMode != TRACKING_MODE) {
+        dashRow(3);
+        dashboard_printf("CONFIG MODE");
+        dashRow(4);
+        dashboard_printf("TARGET NOT SET");
+        dashFooter(now);
+        return;
+    }
+
+    dashRow(2);
+    dashboard_printf("RSSI %d dBm", currentRSSI);
+
+    // Signal bar: -100..-25 dBm mapped to 0..128 px
+    int bar = constrain(map(currentRSSI, -100, -25, 0, 128), 0, 128);
+    dashboard_draw_box(0, 30, (uint16_t)bar, 10);
+    dashboard_draw_hline(0, 41, 128);
+
+    if (targetDetected) {
+        dashRow(6);
+        dashboard_printf("BEEP %ums", (unsigned)calculateBeepInterval(currentRSSI));
+    } else {
+        dashRow(6);
+        dashboard_printf("TARGET LOST");
+    }
+    dashFooter(now);
+}
+
+static void dashPageTarget(unsigned long now) {
+    dashRow(0);
+    dashboard_printf("TARGET DEVICE");
+    dashboard_draw_hline(0, 7, 128);
+
+    if (targetMAC.length() == 0) {
+        dashRow(3);
+        dashboard_printf("NOT CONFIGURED");
+        dashRow(4);
+        dashboard_printf("USE WEB UI TO SET");
+        dashFooter(now);
+        return;
+    }
+
+    dashRow(2);
+    dashboard_printf("%s", targetMAC.c_str());
+    dashRow(3);
+    dashboard_printf(targetDetected ? "STATUS: IN RANGE" : "STATUS: SEARCHING");
+    if (targetDetected) {
+        dashRow(4);
+        dashboard_printf("RSSI %d dBm", currentRSSI);
+        dashRow(5);
+        dashboard_printf("LAST SEEN %lus AGO",
+                         (unsigned long)((now - lastTargetSeen) / 1000UL));
+    }
+    dashFooter(now);
+}
+
+void renderDashboard() {
+    if (!dashboard_present()) return;
+
+    unsigned long now = millis();
+    if (now - lastDashboardRefresh < DASH_REFRESH_MS) return;
+    lastDashboardRefresh = now;
+
+    dashboard_clear();
+    switch (dashPage) {
+        case DASH_PAGE_SUMMARY: dashPageSummary(now); break;
+        case DASH_PAGE_SIGNAL:  dashPageSignal(now); break;
+        case DASH_PAGE_TARGET:  dashPageTarget(now); break;
+        default:                dashPage = DASH_PAGE_SUMMARY; break;
+    }
+    dashboard_flush();
+}
+
 void setup() {
     Serial.begin(115200);
     Serial.println("\n=== OUI-SPY FOXHUNT MODE for Xiao ESP32 S3 ===");
@@ -939,6 +1073,23 @@ void setup() {
     Serial.println("Mode: REALTIME RSSI-based proximity beeping");
     Serial.println("Range: 5s (WEAK) to 100ms (STRONG)");
     Serial.println("Initializing...\n");
+    
+    // Probe for the expansion board OLED. Pins 5/6 are free in this mode, so
+    // this is safe and a no-op when no display is attached.
+    dashboard_init();
+    if (dashboard_present()) {
+        dashboard_clear();
+        dashRow(0);
+        dashboard_printf("FOXHUNTER");
+        dashRow(1);
+        dashboard_printf("RSSI PROXIMITY TRACKER");
+        dashRow(2);
+        dashboard_printf("MODE 2");
+        dashRow(5);
+        dashboard_printf("BOOTING...");
+        dashboard_flush();
+        delay(1200);
+    }
     
     // Setup buzzer - initialize to 1kHz for proximity beeps
     ledcSetup(0, 1000, 8);  // 1kHz default frequency
@@ -990,6 +1141,14 @@ void setup() {
 
 void loop() {
     unsigned long currentTime = millis();
+    
+    // Expansion board button advances the dashboard page (display only)
+    if (dashboard_present() && dashboard_button_pressed()) {
+        dashPage++;
+        if (dashPage >= DASH_PAGE_COUNT) dashPage = 0;
+        lastDashboardRefresh = 0;  // redraw immediately on page change
+    }
+    renderDashboard();
     
     // Handle scheduled mode switch
     if (modeSwitchScheduled > 0 && currentTime >= modeSwitchScheduled) {

--- a/src/raw/foxhunter.cpp
+++ b/src/raw/foxhunter.cpp
@@ -948,6 +948,7 @@ enum DashPage {
     DASH_PAGE_SUMMARY = 0,
     DASH_PAGE_SIGNAL,
     DASH_PAGE_TARGET,
+    DASH_PAGE_QR,
     DASH_PAGE_COUNT
 };
 static uint8_t dashPage = DASH_PAGE_SUMMARY;
@@ -1052,6 +1053,19 @@ static void dashPageTarget(unsigned long now) {
     dashFooter(now);
 }
 
+static void dashPageQR(unsigned long now) {
+    char wifiStr[96];
+    snprintf(wifiStr, sizeof(wifiStr), "WIFI:T:WPA;S:%s;P:%s;;",
+             AP_SSID, AP_PASSWORD);
+    if (!dashboard_draw_qrcode(wifiStr)) {
+        dashRow(2);
+        dashboard_printf("SSID/PASS TOO LONG");
+        dashRow(3);
+        dashboard_printf("FOR QR CODE");
+        dashFooter(now);
+    }
+}
+
 void renderDashboard() {
     if (!dashboard_present()) return;
 
@@ -1064,6 +1078,7 @@ void renderDashboard() {
         case DASH_PAGE_SUMMARY: dashPageSummary(now); break;
         case DASH_PAGE_SIGNAL:  dashPageSignal(now); break;
         case DASH_PAGE_TARGET:  dashPageTarget(now); break;
+        case DASH_PAGE_QR:      dashPageQR(now); break;
         default:                dashPage = DASH_PAGE_SUMMARY; break;
     }
     dashboard_flush();

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -209,10 +209,12 @@ void send_json_fast(const id_data *UAV) {
 
 void bleScanTask(void *parameter) {
   for (;;) {
+    // Short BLE scan with long gap to minimize WiFi promiscuous interference.
+    // ESP32 shares one 2.4GHz radio for BLE and WiFi; aggressive BLE scanning
+    // starves WiFi promiscuous mode, causing missed drone detections.
     NimBLEScanResults foundDevices = pBLEScan->start(1, false);
     pBLEScan->clearResults();
-    // No flag checking needed - BLE callback handles buzzer triggering
-    delay(100);
+    delay(10000);  // 10s gap between scans — gives WiFi promiscuous priority
   }
 }
 
@@ -425,7 +427,7 @@ void setup() {
   NimBLEDevice::init("DroneID");
   pBLEScan = NimBLEDevice::getScan();
   pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
-  pBLEScan->setActiveScan(true);
+  pBLEScan->setActiveScan(false);  // Passive scan — less radio contention with WiFi promisc
 
   printQueue = xQueueCreate(MAX_UAVS, sizeof(id_data));
   

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -48,13 +48,22 @@ struct id_data {
   int      flag;
 };
 
-// Mesh UART on pins D4 (TX) and D5 (RX) for Heltec LoRa gateway
-const int SERIAL1_RX_PIN = 6;
-const int SERIAL1_TX_PIN = 5;
+// Serial1 UART pins. Two roles selected at runtime by expansion board presence:
+//  - Mesh mode (no expansion board): D4/D5 (GPIO5 TX / GPIO6 RX) carry compact
+//    human-readable messages to the Heltec LoRa / Meshtastic gateway.
+//  - Relay mode (expansion board present): the Grove UART on D6/D7 (GPIO43 TX /
+//    GPIO44 RX) carries the full JSON detection stream to a sky-spy-relay board
+//    that forwards it to MQTT. The OLED owns GPIO5/6 in this configuration, so
+//    Serial1 moves to the Grove UART pins instead.
+const int SERIAL1_RX_PIN = 6;   // mesh RX (D5)
+const int SERIAL1_TX_PIN = 5;   // mesh TX (D4)
+const int RELAY_RX_PIN = 44;    // Grove UART RX (D7)
+const int RELAY_TX_PIN = 43;    // Grove UART TX (D6)
 
 void callback(void *, wifi_promiscuous_pkt_type_t);
 void send_json_fast(const id_data *UAV);
 void send_mesh_message(const id_data *UAV);
+void send_mesh_startup(void);
 void buzzerTask(void *parameter);
 
 #define MAX_UAVS 8
@@ -215,14 +224,44 @@ void send_json_fast(const id_data *UAV) {
 }
 
 void send_mesh_message(const id_data *UAV) {
-  // Mesh UART is disabled while the expansion board OLED uses pins 5/6.
-  if (dashboard_present()) return;
+  // Expansion board present: the Grove UART (GPIO43/44) carries the full JSON
+  // detection stream to a sky-spy-relay board that publishes it to MQTT. This
+  // replaces the Heltec mesh forwarding because in a chassis we assume the
+  // detector is NOT wired to a Heltec V3 / Meshtastic node.
+  if (dashboard_present()) {
+    char mac_str[18];
+    snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
+             UAV->mac[0], UAV->mac[1], UAV->mac[2],
+             UAV->mac[3], UAV->mac[4], UAV->mac[5]);
+    char json_msg[256];
+    snprintf(json_msg, sizeof(json_msg),
+      "{\"mac\":\"%s\",\"rssi\":%d,\"drone_lat\":%.6f,\"drone_long\":%.6f,\"drone_altitude\":%d,\"pilot_lat\":%.6f,\"pilot_long\":%.6f,\"basic_id\":\"%s\"}",
+      mac_str, UAV->rssi, UAV->lat_d, UAV->long_d, UAV->altitude_msl,
+      UAV->base_lat_d, UAV->base_long_d, UAV->uav_id);
+    Serial1.println(json_msg);
+    return;
+  }
 
+  // No expansion board: keep the original Heltec LoRa / Meshtastic mesh
+  // forwarding (compact messages on pins 5/6).
   static unsigned long lastSendTime = 0;
-  const unsigned long sendInterval = 5000;
+  static unsigned long droppedSinceLog = 0;
+  static unsigned long lastDropLog = 0;
+  const unsigned long sendInterval = 30000;
   const int MAX_MESH_SIZE = 230;
 
-  if (millis() - lastSendTime < sendInterval) return;
+  if (millis() - lastSendTime < sendInterval) {
+    // Gate closed: drop this frame for the mesh path, but report periodically
+    // so the throttle behavior is visible on USB.
+    droppedSinceLog++;
+    if (millis() - lastDropLog >= 10000) {
+      Serial.printf("[MESH] throttled: %lu frames dropped since last report, next send in %lu ms\n",
+                    droppedSinceLog, sendInterval - (millis() - lastSendTime));
+      droppedSinceLog = 0;
+      lastDropLog = millis();
+    }
+    return;
+  }
   lastSendTime = millis();
 
   char mac_str[18];
@@ -230,28 +269,59 @@ void send_mesh_message(const id_data *UAV) {
            UAV->mac[0], UAV->mac[1], UAV->mac[2],
            UAV->mac[3], UAV->mac[4], UAV->mac[5]);
 
+  // Uptime timestamp prefix so mesh message send times can be correlated
+  // against the Meshtastic notification arrival times.
+  unsigned long nowMs = millis();
+  char ts[12];
+  snprintf(ts, sizeof(ts), "[%02lu:%02lu:%02lu]",
+           nowMs / 3600000UL, nowMs / 60000UL % 60UL, nowMs / 1000UL % 60UL);
+
   char mesh_msg[MAX_MESH_SIZE];
   int msg_len = 0;
   msg_len += snprintf(mesh_msg + msg_len, sizeof(mesh_msg) - msg_len,
-                      "Drone: %s RSSI:%d", mac_str, UAV->rssi);
+                      "%s Drone: %s RSSI:%d", ts, mac_str, UAV->rssi);
   if (msg_len < MAX_MESH_SIZE && UAV->lat_d != 0.0 && UAV->long_d != 0.0) {
     msg_len += snprintf(mesh_msg + msg_len, sizeof(mesh_msg) - msg_len,
                         " https://maps.google.com/?q=%.6f,%.6f",
                         UAV->lat_d, UAV->long_d);
   }
+  // Pilot position folded into the same line so one detection window sends
+  // one Meshtastic message instead of two.
+  if (msg_len < MAX_MESH_SIZE && UAV->base_lat_d != 0.0 && UAV->base_long_d != 0.0) {
+    msg_len += snprintf(mesh_msg + msg_len, sizeof(mesh_msg) - msg_len,
+                        " Pilot: https://maps.google.com/?q=%.6f,%.6f",
+                        UAV->base_lat_d, UAV->base_long_d);
+  }
   if (Serial1.availableForWrite() >= msg_len) {
     Serial1.println(mesh_msg);
+    Serial.printf("[MESH] heltec send: %s\n", mesh_msg);
+  } else {
+    Serial.printf("[MESH] heltec UART full, send skipped (%d bytes needed)\n", msg_len);
   }
+}
 
-  vTaskDelay(pdMS_TO_TICKS(1000));
-  if (UAV->base_lat_d != 0.0 && UAV->base_long_d != 0.0) {
-    char pilot_msg[MAX_MESH_SIZE];
-    int pilot_len = snprintf(pilot_msg, sizeof(pilot_msg),
-                             "Pilot: https://maps.google.com/?q=%.6f,%.6f",
-                             UAV->base_lat_d, UAV->base_long_d);
-    if (Serial1.availableForWrite() >= pilot_len) {
-      Serial1.println(pilot_msg);
-    }
+// Announce boot over the Heltec / Meshtastic link so uptime on the channel
+// can be correlated with the USB log. Relay mode (expansion board) carries
+// JSON only, so the announcement is limited to the headless mesh path.
+// Single-shot: sent once shortly after boot.
+static bool startupSent = false;
+
+void send_mesh_startup(void) {
+  if (dashboard_present() || startupSent) return;
+  startupSent = true;
+
+  unsigned long nowMs = millis();
+  char ts[12];
+  snprintf(ts, sizeof(ts), "[%02lu:%02lu:%02lu]",
+           nowMs / 3600000UL, nowMs / 60000UL % 60UL, nowMs / 1000UL % 60UL);
+
+  char msg[64];
+  int len = snprintf(msg, sizeof(msg), "%s OUI-SPY SkySpy online (headless)", ts);
+  if (Serial1.availableForWrite() >= len) {
+    Serial1.println(msg);
+    Serial.printf("[MESH] startup sent: %s\n", msg);
+  } else {
+    Serial.printf("[MESH] startup skipped (UART full, %d bytes needed)\n", len);
   }
 }
 
@@ -407,16 +477,24 @@ void printerTask(void *param) {
 void initializeSerial() {
   Serial.begin(115200);
 
-  // Probe for the expansion board OLED before touching Serial1. The display
-  // lives on the same two pins (GPIO5/6) as the mesh UART, so when it is
-  // present those pins belong to the I2C bus and mesh forwarding is disabled.
+  // Probe for the expansion board OLED before selecting the Serial1 pins. The
+  // OLED owns GPIO5/6, so when it is present Serial1 moves to the Grove UART
+  // pins (GPIO43/44) and carries the JSON relay stream. Without the expansion
+  // board, Serial1 stays on pins 5/6 for the Heltec LoRa / Meshtastic mesh.
   dashboard_init();
 
+  int rxPin = dashboard_present() ? RELAY_RX_PIN : SERIAL1_RX_PIN;
+  int txPin = dashboard_present() ? RELAY_TX_PIN : SERIAL1_TX_PIN;
+  // Enlarge the TX ring buffer: the timestamped drone+pilot line is ~147 bytes
+  // and must fit in one availableForWrite() window. Must be set before begin().
+  Serial1.setTxBufferSize(512);
+  Serial1.begin(115200, SERIAL_8N1, rxPin, txPin);
+  Serial.printf("[SKY-SPY] Expansion board detected: %s\n", dashboard_present() ? "YES" : "NO");
   if (dashboard_present()) {
-    Serial.println("[SKY-SPY] OLED detected - Serial1 mesh UART disabled (pins 5/6 shared with display)");
-    return;
+    Serial.printf("[SKY-SPY] Relay mode - JSON stream on Grove UART TX=%d RX=%d\n", txPin, rxPin);
+  } else {
+    Serial.printf("[SKY-SPY] Headless mesh mode - compact messages to Heltec on Serial1 TX=%d RX=%d\n", txPin, rxPin);
   }
-  Serial1.begin(115200, SERIAL_8N1, SERIAL1_RX_PIN, SERIAL1_TX_PIN);
 }
 
 void initializeBuzzer() {
@@ -720,6 +798,10 @@ void setup() {
 
 void loop() {
   unsigned long current_millis = millis();
+
+  // Announce boot over the Heltec / Meshtastic link on a retry schedule
+  // (headless only); cheap no-op after the last scheduled attempt.
+  send_mesh_startup();
 
   // Expansion board button advances the dashboard page (display only)
   if (dashboard_present() && dashboard_button_pressed()) {

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -60,6 +60,13 @@ const int SERIAL1_TX_PIN = 5;   // mesh TX (D4)
 const int RELAY_RX_PIN = 44;    // Grove UART RX (D7)
 const int RELAY_TX_PIN = 43;    // Grove UART TX (D6)
 
+// JSON lines pushed out the Grove UART to the sky-spy-relay board. Surfaced on
+// dashboard page 1 so the relay link can be diagnosed from the OLED alone: a
+// counter stuck at 0 while drones are being detected means the relay branch is
+// not running, whereas a climbing counter with no MQTT traffic puts the fault
+// in the cable or on the relay board.
+static unsigned long relayTxCount = 0;
+
 void callback(void *, wifi_promiscuous_pkt_type_t);
 void send_json_fast(const id_data *UAV);
 void send_mesh_message(const id_data *UAV);
@@ -239,6 +246,7 @@ void send_mesh_message(const id_data *UAV) {
       mac_str, UAV->rssi, UAV->lat_d, UAV->long_d, UAV->altitude_msl,
       UAV->base_lat_d, UAV->base_long_d, UAV->uav_id);
     Serial1.println(json_msg);
+    relayTxCount++;
     return;
   }
 
@@ -613,6 +621,8 @@ static void dashPageSummary(const id_data *best, int activeCount, int totalCount
   }
   dashRow(5);
   dashboard_printf("WIFI+BLE PASSIVE");
+  dashRow(6);
+  dashboard_printf("RELAY TX:%lu", relayTxCount);
   dashFooter(now);
 }
 

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -16,7 +16,11 @@
 #include <freertos/task.h>
 
 // Buzzer configuration
-#define BUZZER_PIN 3  // GPIO3 (D2) - PWM capable pin on Xiao ESP32 S3
+// Buzzer pin routing: GPIO3 (D2) for the external oui-spy piezo, or GPIO4
+// (D3/A3) for the expansion board's passive buzzer when the chassis is present.
+// Set in initializeBuzzer() after initializeSerial() has probed for the display.
+static int buzzerPin = BUZZER_PIN_EXTERNAL;
+#define BUZZER_PIN buzzerPin
 
 // LED configuration
 #define LED_PIN 21    // GPIO21 - Built-in orange LED on Xiao ESP32 S3 (inverted logic)
@@ -416,6 +420,10 @@ void initializeSerial() {
 }
 
 void initializeBuzzer() {
+  // Route to the chassis buzzer (GPIO4) when the expansion board is present;
+  // initializeSerial() already probed for the display before this runs.
+  buzzerPin = dashboard_buzzer_pin();
+
   pinMode(BUZZER_PIN, OUTPUT);
   digitalWrite(BUZZER_PIN, LOW);
 
@@ -425,7 +433,7 @@ void initializeBuzzer() {
   ssBuzzerOn = bzP.getBool("on", true);
   bzP.end();
 
-  Serial.printf("Buzzer initialized on GPIO3 (%s)\n", ssBuzzerOn ? "ON" : "OFF");
+  Serial.printf("Buzzer initialized on GPIO%d (%s)\n", buzzerPin, ssBuzzerOn ? "ON" : "OFF");
 }
 
 // Close Encounters of the Third Kind - iconic 5-note motif

--- a/src/raw/skyspy.cpp
+++ b/src/raw/skyspy.cpp
@@ -211,6 +211,9 @@ void send_json_fast(const id_data *UAV) {
 }
 
 void send_mesh_message(const id_data *UAV) {
+  // Mesh UART is disabled while the expansion board OLED uses pins 5/6.
+  if (dashboard_present()) return;
+
   static unsigned long lastSendTime = 0;
   const unsigned long sendInterval = 5000;
   const int MAX_MESH_SIZE = 230;
@@ -399,6 +402,16 @@ void printerTask(void *param) {
 
 void initializeSerial() {
   Serial.begin(115200);
+
+  // Probe for the expansion board OLED before touching Serial1. The display
+  // lives on the same two pins (GPIO5/6) as the mesh UART, so when it is
+  // present those pins belong to the I2C bus and mesh forwarding is disabled.
+  dashboard_init();
+
+  if (dashboard_present()) {
+    Serial.println("[SKY-SPY] OLED detected - Serial1 mesh UART disabled (pins 5/6 shared with display)");
+    return;
+  }
   Serial1.begin(115200, SERIAL_8N1, SERIAL1_RX_PIN, SERIAL1_TX_PIN);
 }
 
@@ -447,6 +460,208 @@ void initializeLED() {
   Serial.println("Orange LED initialized on GPIO21 (inverted logic)");
 }
 
+// ============================================================================
+// Expansion board OLED dashboard (SSD1306/SSD1315 128x64)
+// The 5x7 font uses y as the text baseline, so row i sits at 6 + i*8 pixels.
+// ============================================================================
+#define DASH_REFRESH_MS 1000
+#define DASH_BASELINE 6
+#define DASH_ROW_STEP 8
+
+static unsigned long lastDashboardRefresh = 0;
+
+enum DashPage {
+  DASH_PAGE_SUMMARY = 0,
+  DASH_PAGE_LATEST,
+  DASH_PAGE_POSITION,
+  DASH_PAGE_FLEET,
+  DASH_PAGE_COUNT
+};
+static uint8_t dashPage = DASH_PAGE_SUMMARY;
+
+static void dashRow(uint8_t row) {
+  dashboard_set_cursor(0, DASH_BASELINE + row * DASH_ROW_STEP);
+}
+
+static void dashFormatMac(const uint8_t *mac, char *out, size_t len) {
+  snprintf(out, len, "%02X:%02X:%02X:%02X:%02X:%02X",
+           mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+static const char *dashDroneId(const id_data *uav) {
+  if (uav->op_id[0] != '\0') return uav->op_id;
+  if (uav->uav_id[0] != '\0') return uav->uav_id;
+  return "-";
+}
+
+static void dashFooter(unsigned long now) {
+  dashRow(7);
+  dashboard_printf("P%u/%u UP %02lu:%02lu:%02lu",
+                   (unsigned)(dashPage + 1), (unsigned)DASH_PAGE_COUNT,
+                   (unsigned long)((now / 3600000UL) % 100UL),
+                   (unsigned long)((now / 60000UL) % 60UL),
+                   (unsigned long)((now / 1000UL) % 60UL));
+}
+
+static void dashPageSummary(const id_data *best, int activeCount, int totalCount, unsigned long now) {
+  char mac[18];
+  dashRow(0);
+  dashboard_printf("SKYSPY ACT:%d TOT:%d", activeCount, totalCount);
+  dashboard_draw_hline(0, 7, 128);
+
+  if (activeCount > 0) {
+    dashRow(2);
+    dashboard_printf("DRONE IN RANGE");
+    if (best != NULL) {
+      dashRow(3);
+      dashboard_printf("RSSI %d dBm", best->rssi);
+      dashFormatMac(best->mac, mac, sizeof(mac));
+      dashRow(4);
+      dashboard_printf("%s", mac);
+    }
+  } else {
+    dashRow(2);
+    dashboard_printf("SCANNING FOR DRONES");
+    dashRow(3);
+    dashboard_printf("NO REMOTE ID SIGNAL");
+  }
+  dashRow(5);
+  dashboard_printf("WIFI+BLE PASSIVE");
+  dashFooter(now);
+}
+
+static void dashPageLatest(const id_data *best, unsigned long now) {
+  char mac[18];
+  dashRow(0);
+  dashboard_printf("LATEST DRONE");
+  dashboard_draw_hline(0, 7, 128);
+
+  if (best == NULL) {
+    dashRow(3);
+    dashboard_printf("NO DRONE DETECTED");
+    dashFooter(now);
+    return;
+  }
+
+  dashFormatMac(best->mac, mac, sizeof(mac));
+  dashRow(2);
+  dashboard_printf("MAC %s", mac);
+  dashRow(3);
+  dashboard_printf("RSSI %d dBm", best->rssi);
+  dashRow(4);
+  dashboard_printf("ALT %dm SPD %dm/s", best->altitude_msl, best->speed);
+  dashRow(5);
+  dashboard_printf("HDG %d AGL %dm", best->heading, best->height_agl);
+  dashRow(6);
+  dashboard_printf("ID %s", dashDroneId(best));
+  dashFooter(now);
+}
+
+static void dashPagePosition(const id_data *best, unsigned long now) {
+  dashRow(0);
+  dashboard_printf("DRONE POSITION");
+  dashboard_draw_hline(0, 7, 128);
+
+  if (best == NULL) {
+    dashRow(3);
+    dashboard_printf("NO DRONE DETECTED");
+    dashFooter(now);
+    return;
+  }
+
+  if (best->lat_d != 0.0 && best->long_d != 0.0) {
+    dashRow(2);
+    dashboard_printf("LAT %.5f", best->lat_d);
+    dashRow(3);
+    dashboard_printf("LON %.5f", best->long_d);
+  } else {
+    dashRow(2);
+    dashboard_printf("POSITION NOT RX'D");
+    dashRow(3);
+    dashboard_printf("LAT/LON UNAVAILABLE");
+  }
+  dashRow(4);
+  dashboard_printf("ALT %dm AGL %dm", best->altitude_msl, best->height_agl);
+
+  if (best->base_lat_d != 0.0 && best->base_long_d != 0.0) {
+    dashRow(5);
+    dashboard_printf("PILOT LAT %.5f", best->base_lat_d);
+    dashRow(6);
+    dashboard_printf("PILOT LON %.5f", best->base_long_d);
+  } else {
+    dashRow(5);
+    dashboard_printf("PILOT POS N/A");
+  }
+  dashFooter(now);
+}
+
+static void dashPageFleet(int totalCount, unsigned long now) {
+  id_data *list[MAX_UAVS];
+  int n = 0;
+  for (int i = 0; i < MAX_UAVS; i++) {
+    if (uavs[i].mac[0] != 0) list[n++] = &uavs[i];
+  }
+  // Insertion sort, strongest signal first
+  for (int i = 1; i < n; i++) {
+    id_data *key = list[i];
+    int j = i - 1;
+    while (j >= 0 && list[j]->rssi < key->rssi) {
+      list[j + 1] = list[j];
+      j--;
+    }
+    list[j + 1] = key;
+  }
+
+  dashRow(0);
+  dashboard_printf("FLEET TOT:%d", totalCount);
+  dashboard_draw_hline(0, 7, 128);
+
+  int shown = 0;
+  for (int i = 0; i < n && shown < 5; i++) {
+    char mac[18];
+    dashFormatMac(list[i]->mac, mac, sizeof(mac));
+    dashRow(2 + shown);
+    dashboard_printf("%d %s %d", i + 1, mac, list[i]->rssi);
+    shown++;
+  }
+  if (n > 5) {
+    dashRow(6);
+    dashboard_printf("...and %d more", n - 5);
+  }
+  dashFooter(now);
+}
+
+void renderDashboard() {
+  if (!dashboard_present()) return;
+
+  unsigned long now = millis();
+  if (now - lastDashboardRefresh < DASH_REFRESH_MS) return;
+  lastDashboardRefresh = now;
+
+  int activeCount = 0, totalCount = 0;
+  id_data *best = NULL;
+  uint32_t bestLast = 0;
+  for (int i = 0; i < MAX_UAVS; i++) {
+    if (uavs[i].mac[0] == 0) continue;
+    totalCount++;
+    if (now - uavs[i].last_seen < 10000) activeCount++;
+    if (uavs[i].last_seen >= bestLast) {
+      bestLast = uavs[i].last_seen;
+      best = &uavs[i];
+    }
+  }
+
+  dashboard_clear();
+  switch (dashPage) {
+    case DASH_PAGE_SUMMARY:  dashPageSummary(best, activeCount, totalCount, now); break;
+    case DASH_PAGE_LATEST:   dashPageLatest(best, now); break;
+    case DASH_PAGE_POSITION: dashPagePosition(best, now); break;
+    case DASH_PAGE_FLEET:    dashPageFleet(totalCount, now); break;
+    default:                 dashPage = DASH_PAGE_SUMMARY; break;
+  }
+  dashboard_flush();
+}
+
 void setup() {
   setCpuFrequencyMhz(160);
   initializeSerial();
@@ -455,7 +670,22 @@ void setup() {
   
   // Close Encounters boot melody
   playCloseEncounters();
-  
+
+  // Brief boot splash on the expansion board OLED
+  if (dashboard_present()) {
+    dashboard_clear();
+    dashboard_set_cursor(0, DASH_BASELINE + 0 * DASH_ROW_STEP);
+    dashboard_printf("SKY SPY");
+    dashboard_set_cursor(0, DASH_BASELINE + 1 * DASH_ROW_STEP);
+    dashboard_printf("DRONE REMOTE ID MONITOR");
+    dashboard_set_cursor(0, DASH_BASELINE + 2 * DASH_ROW_STEP);
+    dashboard_printf("MODE 5 WIFI+BLE");
+    dashboard_set_cursor(0, DASH_BASELINE + 5 * DASH_ROW_STEP);
+    dashboard_printf("BOOTING...");
+    dashboard_flush();
+    delay(1500);
+  }
+
   nvs_flash_init();
   
   WiFi.mode(WIFI_STA);
@@ -482,7 +712,15 @@ void setup() {
 
 void loop() {
   unsigned long current_millis = millis();
-  
+
+  // Expansion board button advances the dashboard page (display only)
+  if (dashboard_present() && dashboard_button_pressed()) {
+    dashPage++;
+    if (dashPage >= DASH_PAGE_COUNT) dashPage = 0;
+    lastDashboardRefresh = 0;  // redraw immediately on page change
+  }
+  renderDashboard();
+
   // Status message every 60 seconds
   if ((current_millis - last_status) > 60000UL) {
     Serial.println("{\"   [+] Device is active and scanning...\"}");


### PR DESCRIPTION
when seeed studio xioa expansion board is detected, use it's display and buttons to provide a boot mode selector and dashboard pages for each mode.

you may also like my mapping tool for sky-spy mode
https://github.com/suteny0r/SKY-SPY-Aware/releases/tag/v1.1.0

it feeds serial port data to MQTT server

example subscriber config included, for display on remote machine.

and and android app that does the same thing (subscribe only) https://github.com/suteny0r/SKY-SPY-Aware-android/releases/tag/v1.0.0

This allows multiple sensors to be deployed in an area and a wide audience of phone clients can see the activity in real time.

I'm going to try to move the mqtt publish into an esp32, but will probably have to use a pair of them because of connectivity.

congrats on the defcon appearance.  :)