### PR TITLE
Mode 3: scrub first name from attribution comment

### DIFF
--- a/src/raw/flockyou_promiscious.cpp
+++ b/src/raw/flockyou_promiscious.cpp
@@ -151,7 +151,7 @@ static const char* target_ouis[] = {
   "70:08:94", "58:8e:81", "ec:1b:bd", "3c:71:bf", "58:00:e3",
   "90:35:ea", "5c:93:a2", "64:6e:69", "48:27:ea", "a4:cf:12",
   "14:b5:cd",
-  "82:6b:f2"  // contributed by Michael / DeFlockJoplin
+  "82:6b:f2"  // contributed by DeFlockJoplin
 };
 static const size_t OUI_COUNT = sizeof(target_ouis) / sizeof(target_ouis[0]);
 


### PR DESCRIPTION
Removes first name from the OUI attribution comment in src/raw/flockyou_promiscious.cpp. Matches the git history rewrite of the upstream flock-you repo.