### PR TITLE
feat: Mode 7 Visual Scout — GPS + Deflock DB + Pi 5/Coral camera detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-mode surveillance detection and BLE intelligence firmware for the **Seeed Studio XIAO ESP32-S3**.
 
-One device. Six firmware modes. Select from a boot menu, reboot, and go.
+One device. Seven firmware modes. Select from a boot menu, reboot, and go.
 
 ---
 
@@ -156,6 +156,53 @@ Passive BLE advertising capture. Listens on the three BLE advertising channels (
 - Vendor identify against the OUI Database (same list surfaced by PCAP and Detector)
 - The USB PCAP binary streaming path (previously extcap / pipe helpers) has been removed — ESP32-S3 Arduino USB CDC is not reliable for high-rate binary streaming. Use the dashboard **Save PCAP** button instead; the download parses cleanly in Wireshark regardless of capture rate.
 
+### Mode 7: Visual Scout
+
+Multi-sensor Flock camera detection that catches both RF-transmitting cameras (via GPS + DeFlock database) and RF-silent cameras (via MJPEG stream + Raspberry Pi 5 + Google Coral TPU visual inference). A bridge between passive RF detection and active computer vision.
+
+**Hardware requirements:**
+- GPS module (9600 baud NMEA) on GPIO 44 (RX) / 43 (TX)
+- OV2640 camera (via standard ESP32-S3 WROOM FPC breakout — adjust `CAM_PIN_*` in firmware for your PCB)
+- Raspberry Pi 5 (optional for visual detection; operates autonomously without Pi if only GPS proximity alerts are desired)
+- Google Coral Edge TPU (USB or M.2 via Pi HAT — optional, falls back to CPU YOLOv8)
+
+**Detection methods:**
+
+1. **GPS proximity alerting** — Haversine distance check every 2 seconds against downloaded Flock camera locations from the DeFlock database (~20–30K cameras filtered from ~117K total ALPR nodes). Buzzer + LED alert within configurable radius (default 150 m).
+
+2. **Visual detection** — MJPEG stream from ESP32 OV2640 flows to a Raspberry Pi running YOLOv8 (CPU or Coral TPU accelerated). Every detection is saved with GPS metadata and frame-level annotations to the Pi's NVMe SSD as training data. Supports crowd-source uploads to a central server for collaborative model retraining.
+
+**Deflock database sync:**
+- **Preferred path:** Pi proxy (`pi/deflock_downloader.py`) — downloads full camera list from `data.dontgetflocked.com`, filters to Flock Safety only, serves compact binary at `http://<pi>:5000/flock_cameras.bin` for the ESP32 to fetch (fastest, ~30 KB payload)
+- **Fallback:** ESP32 fetches CDN tiles directly from `cdn.deflock.me` (slower, on-device filtering to Flock Safety brand)
+
+**Features:**
+
+- AP: `ouispy-scout` (open by default; set password via web UI if desired)
+- Dashboard at `http://192.168.4.1` — configure Pi proxy URL, alert radius, WiFi STA credentials for direct CDN sync, view GPS status, trigger manual DB sync
+- MJPEG stream on port 81 (`http://192.168.4.1:81/stream`) — real-time camera feed for the Pi consumer via `cv2.VideoCapture` or `requests` streaming
+- GPS endpoint at `http://192.168.4.1:81/gps` — JSON current position for synchronization with visual detections
+- Compact binary DB in LittleFS: `uint32 camera count` + `N × {float32 lat, float32 lon}`
+- Dedicated FreeRTOS task for MJPEG streaming (core 0), GPS parse on loop (core 1)
+
+**Raspberry Pi pipeline (`pi/`):**
+
+- **`pi/deflock_downloader.py`** — HTTP service on port 5000. Downloads from `data.dontgetflocked.com/cameras-us.json` (primary, fastest), falls back to `data.dontgetflocked.com/cameras.geojson.gz` or `cdn.deflock.me` tiles. Re-syncs every 6 hours. Serves `/flock_cameras.bin` (compact binary), `/flock_cameras.geojson` (for QGIS), `/status` (JSON), and accepts `POST /sync` for manual trigger.
+
+- **`pi/flock_detector.py`** — MJPEG stream consumer. Runs YOLOv8 inference (CPU baseline) or Coral Edge TPU compiled `.tflite` model via `pycoral`. Saves annotated frames + JSON metadata sidecars to NVMe SSD (`/mnt/ssd/training_data/YYYYMMDD/`). Optional background upload thread for crowd-source training data servers.
+
+- **`pi/SETUP.md`** — Full guide: NVMe mount, Coral Edge TPU runtime installation, `edgetpu_compiler` model conversion, systemd service setup.
+
+**Workflow:**
+```
+Driving
+  ├─ ESP32 GPS alert on known Flock cameras (RF-silent or RF-on)
+  └─ ESP32 MJPEG → Pi → Coral TPU detection of new/unknown cameras
+                        ├─ Save frames + GPS to SSD
+                        ├─ Optional: upload to crowd-source server
+                        └─ Retrain shared model
+```
+
 ---
 
 ## WiFi Access Points
@@ -174,6 +221,7 @@ Each mode creates its own AP. When switching modes, **your phone/laptop will aut
 | **PCAP** | `ouispy-pcap` | `packetsniffer` | `192.168.4.1` | Configurable from mode dashboard, saved to NVS. Hop mode disables the AP — radio is dedicated to sniffing; use USB-CDC then |
 | **Sky Spy** | *none* | — | — | No AP — passive scanner, serial JSON output only |
 | **BLE Sniff** | `ouispy-blesniff` | `sniffuntothem` | `192.168.4.1` | Configurable from mode dashboard, saved to NVS |
+| **Visual Scout** | `ouispy-scout` | *(open)* | `192.168.4.1` | GPS + Deflock DB proximity alerts + MJPEG camera stream for Pi/Coral; set password & configure Pi proxy URL from dashboard |
 
 > **Tip:** If you can't reach the dashboard after a mode switch, check which WiFi network you're connected to. Your device may have auto-joined a previously saved OUI-SPY AP from a different mode.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Multi-sensor Flock camera detection that catches both RF-transmitting cameras (v
 
 - AP: `ouispy-scout` (open by default; set password via web UI if desired)
 - Dashboard at `http://192.168.4.1` — configure Pi proxy URL, alert radius, WiFi STA credentials for direct CDN sync, view GPS status, trigger manual DB sync
+- Camera lens profile toggle in dashboard: **IR-cut** (default daylight color) vs **No IR-cut** (night/NIR flash visibility profile)
 - MJPEG stream on port 81 (`http://192.168.4.1:81/stream`) — real-time camera feed for the Pi consumer via `cv2.VideoCapture` or `requests` streaming
 - GPS endpoint at `http://192.168.4.1:81/gps` — JSON current position for synchronization with visual detections
 - Compact binary DB in LittleFS: `uint32 camera count` + `N × {float32 lat, float32 lon}`

--- a/pi/SETUP.md
+++ b/pi/SETUP.md
@@ -1,0 +1,219 @@
+# Visual Scout — Raspberry Pi Setup Guide
+
+## Hardware
+
+| Component | Notes |
+|-----------|-------|
+| Raspberry Pi 5 (4 GB+) | Primary compute node |
+| Google Coral M.2 Accelerator (A+E key) | Edge TPU; fits Pi 5's M.2 HAT slot |
+| Pi 5 M.2 HAT+ | Provides both the PCIe M.2 slot for Coral **and** the NVMe SSD slot — you'll need an M.2 HAT that breaks out two slots, or use a USB Coral instead |
+| NVMe SSD (M.2 2280, PCIe) | Training data storage — 500 GB+ recommended |
+| Power supply | Pi 5 official 27 W USB-C PSU |
+
+> **Note on M.2 slots:** The Pi 5 M.2 HAT provides a single PCIe lane.
+> Use a **USB Coral** (`g950-04594-01`) alongside the NVMe SSD if you want
+> both TPU and SSD without a dual-slot adapter.
+
+---
+
+## 1. Raspberry Pi OS Setup
+
+```bash
+# Install Raspberry Pi OS Bookworm (64-bit, full) via rpi-imager
+# Enable SSH in rpi-imager Advanced Options
+
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y python3-pip python3-venv git libopencv-dev python3-opencv
+```
+
+## 2. Mount the NVMe SSD
+
+```bash
+# Format (first time only)
+sudo mkfs.ext4 /dev/nvme0n1
+
+sudo mkdir -p /mnt/ssd
+echo "/dev/nvme0n1  /mnt/ssd  ext4  defaults,nofail  0  2" | sudo tee -a /etc/fstab
+sudo mount -a
+sudo chown $USER:$USER /mnt/ssd
+mkdir -p /mnt/ssd/training_data
+```
+
+## 3. Install Python Dependencies
+
+```bash
+cd pi/
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 4. Install Coral Edge TPU Runtime (optional but recommended)
+
+```bash
+echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" \
+  | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt update
+sudo apt install -y libedgetpu1-std
+
+# For USB Coral:
+sudo apt install -y gasket-dkms
+
+pip install pycoral
+```
+
+## 5. Get / Train the Flock Camera Model
+
+### Option A — Use a community-trained model (recommended to start)
+
+```bash
+mkdir -p pi/models
+# Download latest model from the project releases (placeholder URL):
+# wget https://github.com/colonelpanichacks/oui-spy-unified-blue/releases/latest/download/flock_yolov8n.pt \
+#   -O pi/models/flock_yolov8n.pt
+```
+
+### Option B — Bootstrap with YOLOv8 nano (no Flock-specific training yet)
+
+The pipeline will run inference with the base COCO model until you have
+enough labelled training data. Camera-shaped objects will be flagged and
+saved even without a custom model — use those saves to build your dataset.
+
+```bash
+# YOLOv8n downloads automatically on first run (ultralytics caches it)
+```
+
+### Option C — Convert to Edge TPU .tflite for Coral
+
+```bash
+# Install Edge TPU compiler
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" \
+  | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
+sudo apt install -y edgetpu-compiler
+
+# Export from ultralytics (produces flock_yolov8n_full_integer_quant.tflite)
+yolo export model=pi/models/flock_yolov8n.pt format=tflite int8
+
+# Compile for Edge TPU
+edgetpu_compiler pi/models/flock_yolov8n_full_integer_quant.tflite \
+  -o pi/models/
+# Output: flock_yolov8n_full_integer_quant_edgetpu.tflite
+```
+
+---
+
+## 6. Start the Deflock DB Proxy
+
+This downloads all known Flock Safety camera locations and serves them to
+the ESP32 in compact binary format.
+
+```bash
+source .venv/bin/activate
+python3 pi/deflock_downloader.py
+# Server runs on port 5000
+# First sync takes ~30–60 seconds
+```
+
+Set the ESP32's **Pi Proxy URL** (in the Visual Scout config UI at
+http://192.168.4.1) to:
+```
+http://<pi-ip>:5000/flock_cameras.bin
+```
+
+Then press **SYNC DB** on the ESP32's web UI.
+
+---
+
+## 7. Start the Visual Detector
+
+```bash
+source .venv/bin/activate
+
+# CPU-only (slower, no Coral)
+python3 pi/flock_detector.py --esp32 http://192.168.4.1
+
+# With Coral Edge TPU
+python3 pi/flock_detector.py --esp32 http://192.168.4.1 --coral \
+  --coral-model pi/models/flock_yolov8n_full_integer_quant_edgetpu.tflite
+
+# With live preview + auto-upload to crowd-source server
+python3 pi/flock_detector.py \
+  --esp32 http://192.168.4.1 \
+  --show \
+  --upload-url https://your-upload-server.example/api/detections
+```
+
+Training data is saved to `/mnt/ssd/training_data/YYYYMMDD/`.
+
+---
+
+## 8. Run as systemd Services (recommended for driving)
+
+```bash
+# Deflock downloader
+sudo tee /etc/systemd/system/deflock-proxy.service <<EOF
+[Unit]
+Description=Deflock DB Proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=$USER
+WorkingDirectory=$(pwd)
+ExecStart=$(pwd)/pi/.venv/bin/python3 $(pwd)/pi/deflock_downloader.py
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Visual detector
+sudo tee /etc/systemd/system/flock-detector.service <<EOF
+[Unit]
+Description=Flock Visual Detector
+After=network-online.target deflock-proxy.service
+
+[Service]
+User=$USER
+WorkingDirectory=$(pwd)
+ExecStart=$(pwd)/pi/.venv/bin/python3 $(pwd)/pi/flock_detector.py --esp32 http://192.168.4.1
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable deflock-proxy flock-detector
+sudo systemctl start  deflock-proxy flock-detector
+```
+
+---
+
+## 9. Training Data Upload Format
+
+When `--upload-url` is set, each detection POSTs a `multipart/form-data` request:
+
+| Field  | Type    | Content |
+|--------|---------|---------|
+| `frame`| file    | Annotated JPEG (annotated frame with detection boxes) |
+| `meta` | text    | JSON string with `ts_utc`, `lat`, `lon`, `detections[]`, `model` |
+
+A minimal Flask upload server is straightforward to self-host.
+
+---
+
+## 10. Workflow Summary
+
+```
+Drive past area → ESP32 WiFi/BLE sniffs (existing modes)
+                → ESP32 GPS alerts on known Flock DB cameras
+                → ESP32 MJPEG stream → Pi + Coral TPU detects NEW cameras
+                → Detections saved to NVMe SSD with GPS tags
+                → Upload to crowd-source server for model retraining
+                → Retrained model shared back → better detections for everyone
+```

--- a/pi/deflock_downloader.py
+++ b/pi/deflock_downloader.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+deflock_downloader.py — Raspberry Pi Deflock DB proxy for Visual Scout
+
+Downloads the full DeFlock camera list, filters it to Flock Safety cameras
+only, and serves a compact binary file the ESP32 can fetch directly.
+
+Binary format (same as deflock.bin on the ESP32):
+  4 bytes   uint32_le  — camera count N
+  N × 8     float32_le lat, float32_le lon
+
+Usage:
+  python3 deflock_downloader.py [--host 0.0.0.0] [--port 5000]
+
+The ESP32's "Pi Proxy URL" should be set to:
+  http://<this-pi-ip>:5000/flock_cameras.bin
+
+The endpoint also serves:
+  GET /flock_cameras.bin   — compact binary (ESP32 format)
+  GET /flock_cameras.geojson — filtered GeoJSON for GIS tools
+  GET /status              — JSON status (camera count, last sync, version)
+  POST /sync               — trigger a manual re-download
+"""
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import struct
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import BytesIO
+from pathlib import Path
+
+import requests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("deflock_dl")
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+CACHE_DIR = Path(__file__).parent / "cache"
+CACHE_DIR.mkdir(exist_ok=True)
+
+BIN_PATH     = CACHE_DIR / "flock_cameras.bin"
+GEOJSON_PATH = CACHE_DIR / "flock_cameras.geojson"
+STATUS_PATH  = CACHE_DIR / "status.json"
+
+# Download sources — tried in order
+SOURCES = [
+    # Plain JSON array — fastest to parse, confirmed publicly accessible
+    {
+        "name": "data.dontgetflocked.com cameras-us.json",
+        "url":  "https://data.dontgetflocked.com/cameras-us.json",
+        "fmt":  "json_array",
+    },
+    # GeoJSON FeatureCollection (may be Cloudflare-gated for some clients)
+    {
+        "name": "data.dontgetflocked.com cameras.geojson.gz",
+        "url":  "https://data.dontgetflocked.com/cameras.geojson.gz",
+        "fmt":  "geojson_gz",
+    },
+    # Overpass query — authoritative but slowest
+    {
+        "name": "Overpass ALPR query",
+        "url":  "https://overpass.deflock.org/api/interpreter",
+        "fmt":  "overpass",
+        "data": (
+            '[out:json][timeout:55];'
+            '('
+            '  node["man_made"="surveillance"]["surveillance:type"="ALPR"]'
+            '      ["brand"="Flock Safety"];'
+            '  way["man_made"="surveillance"]["surveillance:type"="ALPR"]'
+            '     ["brand"="Flock Safety"];'
+            ');'
+            'out center;'
+        ),
+    },
+]
+
+REQUEST_HEADERS = {
+    "User-Agent": "OUI-Spy/VisualScout (ESP32 camera bridge; +https://github.com/colonelpanichacks/oui-spy-unified-blue)",
+    "Accept": "application/json, application/geo+json, */*",
+}
+
+# Tags that indicate a Flock Safety camera
+FLOCK_KEYWORDS = ("flock safety", "flock")
+
+
+def _is_flock(tags: dict) -> bool:
+    """Return True if any relevant tag contains a Flock Safety identifier."""
+    check_keys = ("brand", "surveillance:brand", "surveillance:manufacturer",
+                  "operator", "manufacturer")
+    for k in check_keys:
+        v = str(tags.get(k, "")).lower()
+        if any(kw in v for kw in FLOCK_KEYWORDS):
+            return True
+    return False
+
+
+# ── Downloader ────────────────────────────────────────────────────────────────
+
+sync_lock  = threading.Lock()
+sync_state = {"running": False, "msg": "Not synced yet", "cameras": 0, "ts": 0}
+
+
+def _parse_json_array(raw: bytes) -> list[tuple[float, float]]:
+    """Parse flat JSON array: [{id, lat, lon, tags:{...}}, ...]"""
+    data = json.loads(raw)
+    cameras = []
+    for node in data:
+        tags = node.get("tags", {})
+        if not _is_flock(tags):
+            continue
+        lat = node.get("lat") or node.get("center", {}).get("lat")
+        lon = node.get("lon") or node.get("center", {}).get("lon")
+        if lat is None or lon is None:
+            continue
+        cameras.append((float(lat), float(lon)))
+    return cameras
+
+
+def _parse_geojson(raw: bytes) -> list[tuple[float, float]]:
+    """Parse GeoJSON FeatureCollection."""
+    fc = json.loads(raw)
+    cameras = []
+    for feat in fc.get("features", []):
+        props = feat.get("properties", {})
+        if not _is_flock(props):
+            continue
+        coords = feat.get("geometry", {}).get("coordinates", [])
+        if len(coords) >= 2:
+            cameras.append((float(coords[1]), float(coords[0])))
+    return cameras
+
+
+def _parse_overpass(raw: bytes) -> list[tuple[float, float]]:
+    """Parse Overpass JSON (already filtered by the query)."""
+    data = json.loads(raw)
+    cameras = []
+    for elem in data.get("elements", []):
+        lat = elem.get("lat") or elem.get("center", {}).get("lat")
+        lon = elem.get("lon") or elem.get("center", {}).get("lon")
+        if lat is not None and lon is not None:
+            cameras.append((float(lat), float(lon)))
+    return cameras
+
+
+def write_binary(cameras: list[tuple[float, float]]) -> None:
+    """Write packed binary: uint32 count + N×{float32 lat, float32 lon}."""
+    buf = BytesIO()
+    buf.write(struct.pack("<I", len(cameras)))
+    for lat, lon in cameras:
+        buf.write(struct.pack("<ff", lat, lon))
+    BIN_PATH.write_bytes(buf.getvalue())
+    log.info("Wrote %d cameras to %s (%d KB)", len(cameras), BIN_PATH,
+             len(buf.getvalue()) // 1024)
+
+
+def write_geojson(cameras: list[tuple[float, float]]) -> None:
+    """Write a filtered GeoJSON for use with QGIS / leaflet etc."""
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature",
+             "geometry": {"type": "Point", "coordinates": [lon, lat]},
+             "properties": {"brand": "Flock Safety"}}
+            for lat, lon in cameras
+        ],
+    }
+    GEOJSON_PATH.write_text(json.dumps(fc))
+
+
+def _do_sync():
+    with sync_lock:
+        if sync_state["running"]:
+            return
+        sync_state["running"] = True
+
+    cameras: list[tuple[float, float]] = []
+    last_err = ""
+
+    for src in SOURCES:
+        log.info("Trying source: %s", src["name"])
+        try:
+            if src["fmt"] == "overpass":
+                resp = requests.post(src["url"], data={"data": src["data"]},
+                                     headers=REQUEST_HEADERS, timeout=60)
+            else:
+                resp = requests.get(src["url"], headers=REQUEST_HEADERS, timeout=60)
+            resp.raise_for_status()
+
+            raw = resp.content
+            if src["fmt"] == "geojson_gz":
+                raw = gzip.decompress(raw)
+
+            parsers = {
+                "json_array": _parse_json_array,
+                "geojson_gz": _parse_geojson,
+                "geojson":    _parse_geojson,
+                "overpass":   _parse_overpass,
+            }
+            cameras = parsers[src["fmt"]](raw)
+            log.info("Source %s → %d Flock cameras", src["name"], len(cameras))
+            if cameras:
+                break
+        except Exception as exc:
+            last_err = str(exc)
+            log.warning("Source %s failed: %s", src["name"], exc)
+
+    if cameras:
+        write_binary(cameras)
+        write_geojson(cameras)
+        msg = f"OK — {len(cameras):,} Flock Safety cameras"
+    else:
+        msg = f"All sources failed. Last error: {last_err}"
+        log.error(msg)
+
+    with sync_lock:
+        sync_state.update({"running": False, "msg": msg,
+                            "cameras": len(cameras), "ts": int(time.time())})
+
+    STATUS_PATH.write_text(json.dumps(sync_state))
+
+
+def sync_background():
+    threading.Thread(target=_do_sync, daemon=True).start()
+
+
+# ── HTTP server ───────────────────────────────────────────────────────────────
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        log.debug("HTTP %s", fmt % args)
+
+    def send_json(self, data: dict, code: int = 200):
+        body = json.dumps(data).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+
+        if path == "/flock_cameras.bin":
+            if not BIN_PATH.exists():
+                self.send_json({"error": "No DB yet — POST /sync first"}, 503)
+                return
+            data = BIN_PATH.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(data)
+
+        elif path == "/flock_cameras.geojson":
+            if not GEOJSON_PATH.exists():
+                self.send_json({"error": "No GeoJSON yet — POST /sync first"}, 503)
+                return
+            data = GEOJSON_PATH.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/geo+json")
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(data)
+
+        elif path == "/status":
+            s = dict(sync_state)
+            s["bin_exists"]   = BIN_PATH.exists()
+            s["bin_bytes"]    = BIN_PATH.stat().st_size if BIN_PATH.exists() else 0
+            self.send_json(s)
+
+        else:
+            self.send_json({"error": "Not found"}, 404)
+
+    def do_POST(self):
+        if self.path == "/sync":
+            sync_background()
+            self.send_json({"ok": True, "msg": "Sync started"})
+        else:
+            self.send_json({"error": "Not found"}, 404)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Deflock DB proxy for Visual Scout")
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=5000)
+    ap.add_argument("--sync-on-start", action="store_true", default=True,
+                    help="Trigger a sync immediately on startup (default: on)")
+    ap.add_argument("--no-sync-on-start", dest="sync_on_start", action="store_false")
+    ap.add_argument("--sync-interval-h", type=float, default=6,
+                    help="Re-sync interval in hours (default: 6)")
+    args = ap.parse_args()
+
+    # Load cached status
+    if STATUS_PATH.exists():
+        try:
+            sync_state.update(json.loads(STATUS_PATH.read_text()))
+        except Exception:
+            pass
+
+    if args.sync_on_start:
+        log.info("Starting initial sync…")
+        sync_background()
+
+    # Background periodic re-sync
+    def _periodic():
+        while True:
+            time.sleep(args.sync_interval_h * 3600)
+            log.info("Periodic sync triggered")
+            sync_background()
+    threading.Thread(target=_periodic, daemon=True).start()
+
+    srv = HTTPServer((args.host, args.port), Handler)
+    log.info("Deflock proxy listening on http://%s:%d", args.host, args.port)
+    log.info("  ESP32 URL: http://<this-ip>:%d/flock_cameras.bin", args.port)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/pi/flock_detector.py
+++ b/pi/flock_detector.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+flock_detector.py — Raspberry Pi 5 + Google Coral TPU visual Flock detector
+
+Consumes the ESP32 Visual Scout's MJPEG camera stream, runs YOLO inference
+(optionally accelerated by Coral Edge TPU), and records detection frames +
+GPS metadata as labelled training data to the NVMe SSD.
+
+Architecture:
+  ┌─────────────────────┐       WiFi
+  │  ESP32-S3 WROOM     │ ──────────────► :81/stream   (MJPEG)
+  │  Visual Scout mode  │ ──────────────► :81/gps      (JSON GPS)
+  └─────────────────────┘
+           │
+    ┌──────▼──────────────────────────────────────────────┐
+    │  flock_detector.py  (Raspberry Pi 5)                │
+    │                                                     │
+    │  1. Pull MJPEG frames via requests streaming        │
+    │  2. Decode JPEG → np.ndarray with cv2               │
+    │  3. Infer with YOLOv8n (CPU) or YOLOv8-coral (TPU) │
+    │  4. Any detection above confidence threshold:       │
+    │     • Annotate frame                                │
+    │     • Fetch current GPS from :81/gps               │
+    │     • Save to training_data/ on NVMe SSD            │
+    │     • Optionally upload to crowd-source server      │
+    └──────────────────────────────────────────────────────┘
+
+Requirements:
+  pip install -r requirements.txt
+  (For Coral TPU: also follow the PyCoral setup at coral.ai/docs/m2/get-started)
+
+Usage:
+  python3 flock_detector.py --esp32 http://192.168.4.1
+
+  Flags:
+    --esp32         ESP32 base URL          [default: http://192.168.4.1]
+    --model         Path to YOLO model      [default: models/flock_yolov8n.pt]
+    --conf          Detection confidence    [default: 0.45]
+    --save-all      Save every frame (not just detections)
+    --output        Training data directory [default: /mnt/ssd/training_data]
+    --upload-url    Crowd-source upload URL [optional]
+    --coral         Use Coral TPU (requires pycoral + Edge TPU runtime)
+    --coral-model   Path to .tflite model   [default: models/flock_yolov8n_edgetpu.tflite]
+    --show          Show live annotated preview (requires display)
+"""
+
+import argparse
+import io
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import cv2
+import numpy as np
+import requests
+from PIL import Image
+
+log = logging.getLogger("flock_detector")
+
+# ── Detection record schema ───────────────────────────────────────────────────
+# Each detection is saved as:
+#   <output_dir>/
+#     YYYYMMDD/
+#       <timestamp>_<lat>_<lon>.jpg        — annotated frame
+#       <timestamp>_<lat>_<lon>.json       — metadata sidecar
+#
+# The JSON sidecar contains:
+#   ts_utc, lat, lon, gps_valid, gps_sats,
+#   detections: [{class, confidence, bbox: [x1,y1,x2,y2]}]
+#   model, esp32_url, frame_w, frame_h
+
+
+def setup_logging(verbose: bool):
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def mjpeg_frames(url: str):
+    """Generator that yields raw JPEG bytes from an MJPEG stream."""
+    log.info("Connecting to MJPEG stream: %s", url)
+    resp = requests.get(url, stream=True, timeout=30)
+    resp.raise_for_status()
+
+    boundary = None
+    ct = resp.headers.get("Content-Type", "")
+    for part in ct.split(";"):
+        part = part.strip()
+        if part.startswith("boundary="):
+            boundary = part[len("boundary="):].encode()
+            break
+
+    buf = b""
+    for chunk in resp.iter_content(chunk_size=16384):
+        buf += chunk
+        while True:
+            # Find JPEG start
+            soi = buf.find(b"\xff\xd8")
+            if soi < 0:
+                buf = buf[-3:]  # keep possible partial marker
+                break
+            eoi = buf.find(b"\xff\xd9", soi + 2)
+            if eoi < 0:
+                break
+            yield buf[soi:eoi + 2]
+            buf = buf[eoi + 2:]
+
+
+def fetch_gps(base_url: str) -> dict:
+    """Fetch current GPS from the ESP32's :81/gps endpoint (best-effort)."""
+    try:
+        r = requests.get(f"{base_url}:81/gps" if ":81" not in base_url else f"{base_url}/gps",
+                         timeout=2)
+        return r.json()
+    except Exception:
+        return {"valid": False, "lat": 0.0, "lon": 0.0, "sats": 0}
+
+
+# ── Model loading ─────────────────────────────────────────────────────────────
+
+def load_yolo_model(model_path: str):
+    """Load a YOLOv8 model via ultralytics."""
+    from ultralytics import YOLO
+    log.info("Loading YOLO model: %s", model_path)
+    model = YOLO(model_path)
+    log.info("YOLO model ready (classes: %s)", list(model.names.values()))
+    return model
+
+
+def load_coral_model(tflite_path: str):
+    """Load a compiled Edge TPU .tflite model via pycoral."""
+    from pycoral.utils.edgetpu import make_interpreter
+    from pycoral.adapters import common as coral_common
+    log.info("Loading Coral model: %s", tflite_path)
+    interp = make_interpreter(tflite_path)
+    interp.allocate_tensors()
+    log.info("Coral interpreter ready. Input: %s", coral_common.input_size(interp))
+    return interp
+
+
+def infer_yolo(model, frame: np.ndarray, conf: float) -> list[dict]:
+    results = model(frame, conf=conf, verbose=False)
+    detections = []
+    for r in results:
+        for box in r.boxes:
+            detections.append({
+                "class":      model.names[int(box.cls)],
+                "confidence": float(box.conf),
+                "bbox":       [float(x) for x in box.xyxy[0]],
+            })
+    return detections
+
+
+def infer_coral(interp, frame: np.ndarray, conf: float,
+                input_size: tuple[int, int]) -> list[dict]:
+    """Run inference on a Coral Edge TPU."""
+    from pycoral.adapters import common as coral_common
+    from pycoral.adapters import detect as coral_detect
+
+    img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+    img = img.resize(input_size, Image.BILINEAR)
+    coral_common.set_input(interp, img)
+    interp.invoke()
+    objs = coral_detect.get_objects(interp, score_threshold=conf)
+    labels = getattr(interp, "_labels", {})
+    return [
+        {
+            "class":      labels.get(obj.id, str(obj.id)),
+            "confidence": float(obj.score),
+            "bbox":       [obj.bbox.xmin, obj.bbox.ymin,
+                           obj.bbox.xmax, obj.bbox.ymax],
+        }
+        for obj in objs
+    ]
+
+
+# ── Training data recorder ────────────────────────────────────────────────────
+
+class TrainingRecorder:
+    """
+    Saves annotated frames + JSON metadata to the NVMe SSD.
+
+    Designed for a Pi 5 with an M.2 HAT (NVMe SSD mounted at /mnt/ssd).
+    Falls back gracefully to any writable directory.
+    """
+
+    def __init__(self, output_dir: str, upload_url: str | None = None):
+        self.root       = Path(output_dir)
+        self.upload_url = upload_url
+        self._lock      = threading.Lock()
+        self._queue: list[dict] = []
+        if upload_url:
+            threading.Thread(target=self._upload_worker, daemon=True).start()
+
+    def record(self, frame: np.ndarray, detections: list[dict],
+               gps: dict, model_name: str, esp32_url: str) -> Path:
+        ts = datetime.now(timezone.utc)
+        day_dir = self.root / ts.strftime("%Y%m%d")
+        day_dir.mkdir(parents=True, exist_ok=True)
+
+        lat_s = f"{gps['lat']:.6f}" if gps.get("valid") else "0.000000"
+        lon_s = f"{gps['lon']:.6f}" if gps.get("valid") else "0.000000"
+        stem  = f"{ts.strftime('%H%M%S_%f')}_{lat_s}_{lon_s}"
+
+        # Annotate frame
+        ann = frame.copy()
+        for d in detections:
+            x1, y1, x2, y2 = [int(v) for v in d["bbox"]]
+            cv2.rectangle(ann, (x1, y1), (x2, y2), (0, 0, 255), 2)
+            label = f"{d['class']} {d['confidence']:.2f}"
+            cv2.putText(ann, label, (x1, y1 - 6),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 1)
+
+        jpg_path  = day_dir / f"{stem}.jpg"
+        json_path = day_dir / f"{stem}.json"
+
+        cv2.imwrite(str(jpg_path), ann, [cv2.IMWRITE_JPEG_QUALITY, 92])
+
+        meta = {
+            "ts_utc":     ts.isoformat(),
+            "lat":        gps.get("lat", 0.0),
+            "lon":        gps.get("lon", 0.0),
+            "gps_valid":  gps.get("valid", False),
+            "gps_sats":   gps.get("sats", 0),
+            "detections": detections,
+            "model":      model_name,
+            "esp32_url":  esp32_url,
+            "frame_w":    frame.shape[1],
+            "frame_h":    frame.shape[0],
+        }
+        json_path.write_text(json.dumps(meta, indent=2))
+
+        log.info("Saved: %s (%d detections)", jpg_path.name, len(detections))
+
+        if self.upload_url:
+            with self._lock:
+                self._queue.append({"jpg": str(jpg_path), "meta": meta})
+
+        return jpg_path
+
+    def _upload_worker(self):
+        """Background thread that uploads recordings to the crowd-source server."""
+        while True:
+            time.sleep(5)
+            with self._lock:
+                items = self._queue[:]
+                self._queue.clear()
+            for item in items:
+                try:
+                    jpg_path = Path(item["jpg"])
+                    if not jpg_path.exists():
+                        continue
+                    with open(jpg_path, "rb") as f:
+                        resp = requests.post(
+                            self.upload_url,
+                            files={"frame": (jpg_path.name, f, "image/jpeg")},
+                            data={"meta": json.dumps(item["meta"])},
+                            timeout=30,
+                        )
+                    if resp.ok:
+                        log.info("Uploaded %s", jpg_path.name)
+                    else:
+                        log.warning("Upload failed %s: HTTP %d", jpg_path.name, resp.status_code)
+                except Exception as exc:
+                    log.warning("Upload error: %s", exc)
+                    with self._lock:
+                        self._queue.insert(0, item)   # retry
+                    break
+
+
+# ── Main detection loop ───────────────────────────────────────────────────────
+
+def run(args):
+    setup_logging(getattr(args, "verbose", False))
+
+    # Resolve stream + GPS URLs
+    base = args.esp32.rstrip("/")
+    # MJPEG stream is on port 81
+    if ":81" in base:
+        stream_url = f"{base}/stream"
+        gps_base   = base
+    else:
+        stream_url = f"{base}:81/stream"
+        gps_base   = f"{base}:81"
+
+    # Load model
+    if args.coral:
+        interp     = load_coral_model(args.coral_model)
+        from pycoral.adapters import common as coral_common
+        input_size = coral_common.input_size(interp)
+        # Load label map if present alongside the model
+        lbl_path = Path(args.coral_model).with_suffix("").parent / "labels.txt"
+        if lbl_path.exists():
+            interp._labels = {i: l.strip()
+                              for i, l in enumerate(lbl_path.read_text().splitlines())}
+        infer = lambda frame: infer_coral(interp, frame, args.conf, input_size)
+        model_name = Path(args.coral_model).stem
+    else:
+        model      = load_yolo_model(args.model)
+        infer      = lambda frame: infer_yolo(model, frame, args.conf)
+        model_name = Path(args.model).stem
+
+    recorder = TrainingRecorder(args.output, getattr(args, "upload_url", None))
+
+    frame_count = 0
+    det_count   = 0
+    t0          = time.time()
+
+    log.info("Starting detection loop (stream: %s)", stream_url)
+    log.info("Training data → %s", args.output)
+
+    for jpg_bytes in mjpeg_frames(stream_url):
+        frame_count += 1
+
+        # Decode
+        arr   = np.frombuffer(jpg_bytes, dtype=np.uint8)
+        frame = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+        if frame is None:
+            continue
+
+        # Infer
+        detections = infer(frame)
+
+        should_save = detections or args.save_all
+        if should_save:
+            gps = fetch_gps(gps_base)
+            recorder.record(frame, detections, gps, model_name, base)
+            det_count += len(detections)
+
+        # Live preview
+        if args.show:
+            ann = frame.copy()
+            for d in detections:
+                x1, y1, x2, y2 = [int(v) for v in d["bbox"]]
+                cv2.rectangle(ann, (x1, y1), (x2, y2), (0, 0, 255), 2)
+                cv2.putText(ann, f"{d['class']} {d['confidence']:.2f}",
+                            (x1, y1 - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 1)
+            fps = frame_count / max(1, time.time() - t0)
+            cv2.putText(ann, f"FPS:{fps:.1f} dets:{det_count}",
+                        (8, 20), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+            cv2.imshow("Visual Scout", ann)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+
+        # Log stats every 100 frames
+        if frame_count % 100 == 0:
+            fps = frame_count / max(1, time.time() - t0)
+            log.info("Frames: %d  Detections: %d  FPS: %.1f",
+                     frame_count, det_count, fps)
+
+    cv2.destroyAllWindows()
+
+
+def main():
+    p = argparse.ArgumentParser(description="Flock camera visual detector (Pi 5 + Coral)")
+    p.add_argument("--esp32",        default="http://192.168.4.1",
+                   help="ESP32 Visual Scout base URL")
+    p.add_argument("--model",        default="models/flock_yolov8n.pt",
+                   help="YOLOv8 model path (.pt or .onnx)")
+    p.add_argument("--conf",         type=float, default=0.45,
+                   help="Detection confidence threshold")
+    p.add_argument("--output",       default="/mnt/ssd/training_data",
+                   help="Training data output directory")
+    p.add_argument("--save-all",     action="store_true",
+                   help="Save every frame, not just detections")
+    p.add_argument("--upload-url",   default=None,
+                   help="POST URL for crowd-source training data upload")
+    p.add_argument("--coral",        action="store_true",
+                   help="Use Coral Edge TPU (requires pycoral + runtime)")
+    p.add_argument("--coral-model",  default="models/flock_yolov8n_edgetpu.tflite",
+                   help="Compiled Edge TPU .tflite model path")
+    p.add_argument("--show",         action="store_true",
+                   help="Show live annotated preview window")
+    p.add_argument("--verbose",      action="store_true")
+    args = p.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pi/requirements.txt
+++ b/pi/requirements.txt
@@ -1,0 +1,31 @@
+# Raspberry Pi 5 — Visual Scout detection pipeline
+# Install with: pip install -r requirements.txt
+#
+# For Coral Edge TPU support, ALSO run:
+#   echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" \
+#     | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
+#   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+#   sudo apt update
+#   sudo apt install libedgetpu1-std gasket-dkms
+#   pip install pycoral  (or: pip install pycoral @ https://github.com/google-coral/pycoral/releases)
+#
+# For NVMe SSD (Pi 5 M.2 HAT):
+#   sudo mkfs.ext4 /dev/nvme0n1
+#   sudo mkdir -p /mnt/ssd
+#   echo "/dev/nvme0n1 /mnt/ssd ext4 defaults,nofail 0 2" | sudo tee -a /etc/fstab
+#   sudo mount -a
+
+# Core
+requests>=2.31.0
+Pillow>=10.0.0
+numpy>=1.24.0
+opencv-python>=4.8.0
+
+# YOLO inference (CPU baseline)
+ultralytics>=8.0.0
+
+# Optional — Coral Edge TPU
+# pycoral  # install separately (see above)
+
+# Deflock downloader service
+# (standard library only — no extra deps needed for deflock_downloader.py)

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     bblanchon/ArduinoJson@^7.0.4
     mikalhart/TinyGPSPlus@^1.1.0
+    espressif/esp32-camera@^2.0.14
 
 ; Flash: 8MB QIO, bootloader at 0x0, partitions at 0x8000, app at 0x10000
 board_build.arduino.memory_type = qio_opi

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     bblanchon/ArduinoJson@^7.0.4
     mikalhart/TinyGPSPlus@^1.1.0
-    espressif/esp32-camera@^2.0.14
+    espressif/esp32-camera@^2.0.4
 
 ; Flash: 8MB QIO, bootloader at 0x0, partitions at 0x8000, app at 0x10000
 board_build.arduino.memory_type = qio_opi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,7 @@ body{margin:0;height:100vh;height:-webkit-fill-available;font-family:monospace;b
 <div class="i" onclick="go(4)"><div class="n">PCAP</div><div class="d">AP: ouispy-pcap &bull; Passive WiFi capture + USB-CDC</div></div>
 <div class="i" onclick="go(5)"><div class="n">SKY SPY</div><div class="d">No AP &bull; Drone Remote ID monitor</div></div>
 <div class="i" onclick="go(6)"><div class="n">BLE SNIFF</div><div class="d">AP: ouispy-blesniff &bull; Passive BLE adverts + USB-CDC</div></div>
+<div class="i" onclick="go(7)"><div class="n">VISUAL SCOUT</div><div class="d">AP: ouispy-scout &bull; GPS + Deflock DB + Camera stream for Pi/Coral</div></div>
 </div>
 <div class="ap">
 <input type="text" id="ap_ssid" placeholder="SSID" maxlength="32" value="%SSID%">
@@ -164,7 +165,7 @@ body{margin:0;height:100vh;height:-webkit-fill-available;font-family:monospace;b
 </div>
 </div>
 <script>
-var info={1:{t:'DETECTOR',s:'AP: snoopuntothem / astheysnoopuntous. Scans for BLE devices and alerts when specific targets are detected. Configure OUI prefixes and MAC addresses to monitor.'},2:{t:'FOXHUNTER',s:'AP: foxhunter / foxhunter. Track down a specific device using RSSI signal strength. Beeps get faster as you get closer to your target.'},3:{t:'FLOCK-YOU WIFI',s:'No AP - USB-CDC only. Passive 2.4 GHz promiscuous-mode detector for Flock Safety. Matches addr1/addr2 OUIs and the DeFlockJoplin wildcard-probe signature. Streams Flask-compatible JSON over USB and persists to SPIFFS; pull history via the CMD:DUMP_PREV protocol.'},4:{t:'PCAP',s:'AP: ouispy-pcap / packetsniffer. Passive WiFi packet capture. Wireshark-ready PCAP over USB-CDC, live web dashboard at http://192.168.4.1, channel hop across the full 2.4 GHz band, in-PSRAM session PCAP for browser download.'},5:{t:'SKY SPY',s:'No AP - serial JSON out. Monitors for FAA Remote ID broadcasts from drones. Detects Open Drone ID signals over WiFi and BLE.'},6:{t:'BLE SNIFF',s:'AP: ouispy-blesniff / sniffuntothem. Passive BLE advertising capture (channels 37/38/39). Wireshark-ready PCAP (linktype 256) over USB-CDC + live dashboard, 2 MB in-PSRAM session PCAP for browser download.'}};
+var info={1:{t:'DETECTOR',s:'AP: snoopuntothem / astheysnoopuntous. Scans for BLE devices and alerts when specific targets are detected. Configure OUI prefixes and MAC addresses to monitor.'},2:{t:'FOXHUNTER',s:'AP: foxhunter / foxhunter. Track down a specific device using RSSI signal strength. Beeps get faster as you get closer to your target.'},3:{t:'FLOCK-YOU WIFI',s:'No AP - USB-CDC only. Passive 2.4 GHz promiscuous-mode detector for Flock Safety. Matches addr1/addr2 OUIs and the DeFlockJoplin wildcard-probe signature. Streams Flask-compatible JSON over USB and persists to SPIFFS; pull history via the CMD:DUMP_PREV protocol.'},4:{t:'PCAP',s:'AP: ouispy-pcap / packetsniffer. Passive WiFi packet capture. Wireshark-ready PCAP over USB-CDC, live web dashboard at http://192.168.4.1, channel hop across the full 2.4 GHz band, in-PSRAM session PCAP for browser download.'},5:{t:'SKY SPY',s:'No AP - serial JSON out. Monitors for FAA Remote ID broadcasts from drones. Detects Open Drone ID signals over WiFi and BLE.'},6:{t:'BLE SNIFF',s:'AP: ouispy-blesniff / sniffuntothem. Passive BLE advertising capture (channels 37/38/39). Wireshark-ready PCAP (linktype 256) over USB-CDC + live dashboard, 2 MB in-PSRAM session PCAP for browser download.'},7:{t:'VISUAL SCOUT',s:'AP: ouispy-scout (open). GPS + Deflock camera DB proximity alerts. Streams OV2640 camera MJPEG on :81/stream for a Raspberry Pi 5 + Coral TPU running YOLOv8 visual detection. Configure Pi proxy URL at http://192.168.4.1 then press SYNC DB.'}};
 function go(m){var d=info[m];document.getElementById('yt').textContent=d.t;document.getElementById('ys').textContent=d.s;document.getElementById('x').style.display='none';document.getElementById('y').style.display='flex';fetch('/select?mode='+m)}
 function saveAP(){
 var s=document.getElementById('ap_ssid').value.trim();
@@ -320,7 +321,7 @@ static void startSelector() {
     selectorServer.on("/select", HTTP_GET, [](AsyncWebServerRequest *request) {
         if (request->hasParam("mode")) {
             int mode = request->getParam("mode")->value().toInt();
-            if (mode >= 1 && mode <= 6) {
+            if (mode >= 1 && mode <= 7) {
                 Serial.printf("[OUI-SPY] USER SELECTED MODE %d - Storing and rebooting\n", mode);
                 
                 // Clear reset flag so double-reset detection doesn't override on next boot
@@ -431,8 +432,9 @@ static void startSelector() {
             case 4: ok = p.begin("pcap-mode", false); if (ok) { p.remove("apssid"); p.remove("appass"); p.end(); } break;
             case 5: /* mode 5 has no AP */ ok = true; break;
             case 6: ok = p.begin("blesniff", false); if (ok) { p.remove("ap_ssid"); p.remove("ap_pass"); p.end(); } break;
+            case 7: ok = p.begin("visual-scout", false); if (ok) { p.clear(); p.end(); } break;
             default:
-                request->send(400, "text/plain", "m must be 1-6");
+                request->send(400, "text/plain", "m must be 1-7");
                 return;
         }
         Serial.printf("[OUI-SPY] /reset_mode m=%d ok=%d\n", m, ok ? 1 : 0);
@@ -533,7 +535,7 @@ void setup() {
         Serial.flush();
 
         // Validate mode range
-        if (currentMode < 0 || currentMode > 6) {
+        if (currentMode < 0 || currentMode > 7) {
             Serial.printf("[OUI-SPY] Invalid stored mode %d, defaulting to selector\n", currentMode);
             currentMode = 0;
         }
@@ -596,6 +598,11 @@ void setup() {
         Serial.println("[OUI-SPY] AP will be: ouispy-blesniff  (dashboard http://192.168.4.1)");
         Serial.flush();
         blesniff_setup();
+    } else if (currentMode == 7) {
+        Serial.println("[OUI-SPY] >>> STARTING VISUAL SCOUT (mode 7) <<<");
+        Serial.println("[OUI-SPY] AP: ouispy-scout  config http://192.168.4.1  stream :81/stream");
+        Serial.flush();
+        visual_scout_setup();
     } else {
         Serial.printf("[OUI-SPY] ERROR: Unknown mode %d, defaulting to selector\n", currentMode);
         Serial.flush();
@@ -654,6 +661,7 @@ void loop() {
         case 4: pcap_loop(); break;
         case 5: skyspy_loop(); break;
         case 6: blesniff_loop(); break;
+        case 7: visual_scout_loop(); break;
         default:
             // Selector mode - web server handles everything
             selectorDNS.processNextRequest();  // Captive portal DNS

--- a/src/mode_visual_scout.cpp
+++ b/src/mode_visual_scout.cpp
@@ -1,0 +1,48 @@
+/*
+ * Mode 7: Visual Scout — GPS proximity + Deflock DB + Camera stream
+ *
+ * Wraps src/raw/visual_scout.cpp in an anonymous namespace so its internal
+ * symbols don't collide with other modes.
+ *
+ * Setup:
+ *   1. Wire a GPS module to GPIO 44 (RX) / 43 (TX)
+ *   2. Wire OV2640 camera per CAM_PIN_* constants in visual_scout.cpp
+ *   3. Flash and connect to WiFi AP "ouispy-scout" (open)
+ *   4. Open http://192.168.4.1 — enter Pi proxy URL or WiFi STA creds,
+ *      then press "SYNC DB" to download Flock camera locations
+ *   5. The Raspberry Pi stream consumer reads http://192.168.4.1:81/stream
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <AsyncTCP.h>
+#include <ESPAsyncWebServer.h>
+#include <Preferences.h>
+#include <LittleFS.h>
+#include <ArduinoJson.h>
+#include <TinyGPSPlus.h>
+#include "esp_camera.h"
+#include "modes.h"
+
+#define setup  visual_scout_ns_setup
+#define loop   visual_scout_ns_loop
+#define stop   visual_scout_ns_stop
+
+namespace {
+#include "raw/visual_scout.cpp"
+} // anonymous namespace
+
+#undef setup
+#undef loop
+#undef stop
+
+void visual_scout_setup() {
+    ouispy_mode_preamble("MODE 7 VISUAL SCOUT");
+    visual_scout_ns_setup();
+    ouispy_log_ap_state("MODE 7 VISUAL SCOUT", /*expectAP=*/true);
+}
+void visual_scout_loop() { visual_scout_ns_loop(); }
+void visual_scout_stop() { visual_scout_ns_stop(); }

--- a/src/mode_visual_scout.cpp
+++ b/src/mode_visual_scout.cpp
@@ -29,7 +29,7 @@
 
 #define setup  visual_scout_ns_setup
 #define loop   visual_scout_ns_loop
-#define stop   visual_scout_ns_stop
+#define modeStop visual_scout_ns_stop
 
 namespace {
 #include "raw/visual_scout.cpp"
@@ -37,7 +37,7 @@ namespace {
 
 #undef setup
 #undef loop
-#undef stop
+#undef modeStop
 
 void visual_scout_setup() {
     ouispy_mode_preamble("MODE 7 VISUAL SCOUT");

--- a/src/modes.h
+++ b/src/modes.h
@@ -42,4 +42,9 @@ void blesniff_setup();
 void blesniff_loop();
 void blesniff_stop();
 
+// Mode 7: Visual Scout — GPS + Deflock DB proximity + Camera stream for Pi/Coral
+void visual_scout_setup();
+void visual_scout_loop();
+void visual_scout_stop();
+
 #endif // MODES_H

--- a/src/raw/visual_scout.cpp
+++ b/src/raw/visual_scout.cpp
@@ -1,0 +1,790 @@
+/*
+ * Visual Scout — raw implementation (src/raw/visual_scout.cpp)
+ *
+ * Wrapped by src/mode_visual_scout.cpp in an anonymous namespace.
+ * Entry points are setup() / loop() (renamed by the wrapper's #define trick).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * FEATURES
+ * ─────────────────────────────────────────────────────────────────────────
+ * 1. Deflock camera DB sync
+ *    - Primary:  Pi-local proxy  http://<pi_ip>:5000/flock_cameras.bin
+ *    - Fallback: cdn.deflock.me  regional tile download (auto-filtered for
+ *                Flock Safety brand in tile JSON)
+ *    - DB stored as compact binary in LittleFS: uint32 count + N×{lat,lon}
+ *
+ * 2. GPS proximity alerting
+ *    - TinyGPSPlus on UART2 (GPS_RX_PIN / GPS_TX_PIN)
+ *    - Haversine check every PROXIMITY_CHECK_INTERVAL_MS
+ *    - Buzzer + LED alert within ALERT_RADIUS_M_DEFAULT of any known camera
+ *
+ * 3. Camera MJPEG stream (port 81)
+ *    - MJPEG stream at  http://192.168.4.1:81/stream
+ *    - JPEG snapshot at http://192.168.4.1:81/snap
+ *    - GPS metadata at  http://192.168.4.1:81/gps  (JSON)
+ *    - Runs in a dedicated FreeRTOS task
+ *
+ * 4. Config AP + web UI (port 80)
+ *    - SSID: ouispy-scout  (no password — or set one via web)
+ *    - Configure Pi proxy IP, alert radius, WiFi creds for sync
+ *    - Trigger manual sync, view GPS status, live DB stats
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * HARDWARE DEFAULTS  (ESP32-S3 WROOM + OV2640 breakout)
+ * ─────────────────────────────────────────────────────────────────────────
+ *  GPS:    RX←GPIO44  TX→GPIO43  9600 baud NMEA
+ *  Camera: adjust CAM_PIN_* below for your PCB; defaults match a common
+ *          ESP32-S3 WROOM + OV2640 FPC breakout
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * NVS namespace: "visual-scout"  (do not reuse in other modes)
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <AsyncTCP.h>
+#include <ESPAsyncWebServer.h>
+#include <Preferences.h>
+#include <LittleFS.h>
+#include <ArduinoJson.h>
+#include <TinyGPSPlus.h>
+#include "esp_camera.h"
+#include "modes.h"
+
+// ============================================================================
+// Hardware
+// ============================================================================
+
+#ifndef BUZZER_PIN
+#define BUZZER_PIN  3
+#endif
+#ifndef LED_PIN
+#define LED_PIN     21
+#endif
+
+#define GPS_RX_PIN  44
+#define GPS_TX_PIN  43
+#define GPS_BAUD    9600
+
+// OV2640 pin mapping — common ESP32-S3 WROOM breakout.
+// Adjust for your specific PCB (see your schematic).
+#define CAM_PIN_PWDN    (-1)
+#define CAM_PIN_RESET   (-1)
+#define CAM_PIN_XCLK     15
+#define CAM_PIN_SIOD      4
+#define CAM_PIN_SIOC      5
+#define CAM_PIN_D7       16
+#define CAM_PIN_D6       17
+#define CAM_PIN_D5       18
+#define CAM_PIN_D4       12
+#define CAM_PIN_D3       10
+#define CAM_PIN_D2        8
+#define CAM_PIN_D1        9
+#define CAM_PIN_D0       11
+#define CAM_PIN_VSYNC     6
+#define CAM_PIN_HREF      7
+#define CAM_PIN_PCLK     13
+
+// ============================================================================
+// Deflock endpoints
+// ============================================================================
+
+// cdn.deflock.me tile API:
+//   GET /regions/index.json            → manifest: { regions, tile_url, tile_size_degrees }
+//   GET /regions/{lat20}/{lon20}.json  → array of camera nodes with lat/lon/tags
+// Tile grid: snap lat/lon down to nearest 20° multiple.
+// Each tile node has a "tags" object; check brand/surveillance:brand for "Flock Safety".
+#define DEFLOCK_CDN_INDEX   "http://cdn.deflock.me/regions/index.json"
+#define DEFLOCK_TILE_BASE   "http://cdn.deflock.me/regions"
+#define DEFLOCK_MAX_CAMERAS  40000   // hard cap; 4 US tiles × ~10K Flock cameras
+
+// ============================================================================
+// Alert thresholds
+// ============================================================================
+
+#define ALERT_RADIUS_M_DEFAULT    150.0f
+#define ALERT_COOLDOWN_MS         8000
+#define PROXIMITY_CHECK_INTERVAL_MS 2000
+
+// ============================================================================
+// File paths
+// ============================================================================
+
+#define DEFLOCK_BIN_PATH   "/deflock.bin"
+#define VS_CONFIG_PATH     "/vs_cfg.json"
+
+// ============================================================================
+// State
+// ============================================================================
+
+struct CameraPos { float lat; float lon; };
+
+struct VSConfig {
+    char  piProxyURL[128] = "";         // e.g. http://192.168.4.2:5000/flock_cameras.bin
+    char  staSSID[64]     = "";         // WiFi STA for internet-direct sync
+    char  staPass[64]     = "";
+    float alertRadiusM    = ALERT_RADIUS_M_DEFAULT;
+    bool  cameraEnabled   = true;
+    bool  buzzerEnabled   = true;
+};
+static VSConfig cfg;
+
+static TinyGPSPlus   gps;
+static HardwareSerial gpsSerial(2);
+
+static AsyncWebServer cfgServer(80);   // config UI
+
+static CameraPos* deflockDB   = nullptr;
+static uint32_t   deflockCount = 0;
+
+static unsigned long lastProxCheck = 0;
+static unsigned long lastAlertMs   = 0;
+static int           lastAlertIdx  = -1;
+static float         lastAlertDistM = 0.0f;
+
+enum SyncState : uint8_t { SS_IDLE=0, SS_BUSY=1, SS_OK=2, SS_ERR=3 };
+static SyncState syncState   = SS_IDLE;
+static String    syncMsg     = "Idle";
+static int       syncPct     = 0;
+
+static bool cameraOK = false;
+
+// MJPEG stream server — runs in its own task on port 81
+static WiFiServer mjpegServer(81);
+static TaskHandle_t mjpegTaskHandle = nullptr;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+static void ledOn()  { digitalWrite(LED_PIN, LOW);  }
+static void ledOff() { digitalWrite(LED_PIN, HIGH); }
+
+static void beep(int hz, int ms) {
+    if (!cfg.buzzerEnabled) return;
+    ledcSetup(0, hz, 8);
+    ledcAttachPin(BUZZER_PIN, 0);
+    ledcWrite(0, 100);
+    delay(ms);
+    ledcWrite(0, 0);
+}
+
+// Haversine distance in metres
+static float haversineM(float lat1, float lon1, float lat2, float lon2) {
+    const float R = 6371000.0f;
+    float dLat = (lat2 - lat1) * (float)DEG_TO_RAD;
+    float dLon = (lon2 - lon1) * (float)DEG_TO_RAD;
+    float a = sinf(dLat*0.5f)*sinf(dLat*0.5f)
+            + cosf(lat1*(float)DEG_TO_RAD)*cosf(lat2*(float)DEG_TO_RAD)
+            * sinf(dLon*0.5f)*sinf(dLon*0.5f);
+    return R * 2.0f * atan2f(sqrtf(a), sqrtf(1.0f - a));
+}
+
+// Snap lat/lon to 20° grid (cdn.deflock.me tile coordinate)
+static int tileCoord(float v) { return (int)floorf(v / 20.0f) * 20; }
+
+// ============================================================================
+// Config I/O
+// ============================================================================
+
+static void loadConfig() {
+    if (!LittleFS.exists(VS_CONFIG_PATH)) return;
+    File f = LittleFS.open(VS_CONFIG_PATH, "r");
+    if (!f) return;
+    JsonDocument doc;
+    if (deserializeJson(doc, f) == DeserializationError::Ok) {
+        strlcpy(cfg.piProxyURL, doc["pi_proxy"]    | "", sizeof(cfg.piProxyURL));
+        strlcpy(cfg.staSSID,    doc["sta_ssid"]    | "", sizeof(cfg.staSSID));
+        strlcpy(cfg.staPass,    doc["sta_pass"]    | "", sizeof(cfg.staPass));
+        cfg.alertRadiusM  = doc["radius_m"]        | ALERT_RADIUS_M_DEFAULT;
+        cfg.cameraEnabled = doc["cam_on"]          | true;
+        cfg.buzzerEnabled = doc["buz_on"]          | true;
+    }
+    f.close();
+}
+
+static void saveConfig() {
+    File f = LittleFS.open(VS_CONFIG_PATH, "w");
+    if (!f) return;
+    JsonDocument doc;
+    doc["pi_proxy"] = cfg.piProxyURL;
+    doc["sta_ssid"] = cfg.staSSID;
+    doc["sta_pass"] = cfg.staPass;
+    doc["radius_m"] = cfg.alertRadiusM;
+    doc["cam_on"]   = cfg.cameraEnabled;
+    doc["buz_on"]   = cfg.buzzerEnabled;
+    serializeJson(doc, f);
+    f.close();
+}
+
+// ============================================================================
+// Deflock DB — load packed binary from LittleFS
+// ============================================================================
+
+static bool loadDeflockBin() {
+    free(deflockDB); deflockDB = nullptr; deflockCount = 0;
+    File f = LittleFS.open(DEFLOCK_BIN_PATH, "r");
+    if (!f) { Serial.println("[VS] No deflock.bin"); return false; }
+    uint32_t n = 0;
+    if (f.read((uint8_t*)&n, 4) != 4 || n == 0 || n > DEFLOCK_MAX_CAMERAS) {
+        f.close(); return false;
+    }
+    deflockDB = (CameraPos*)ps_malloc(n * sizeof(CameraPos));
+    if (!deflockDB) deflockDB = (CameraPos*)malloc(n * sizeof(CameraPos));
+    if (!deflockDB) { f.close(); return false; }
+    size_t got = f.read((uint8_t*)deflockDB, n * sizeof(CameraPos));
+    f.close();
+    if (got != n * sizeof(CameraPos)) {
+        free(deflockDB); deflockDB = nullptr; return false;
+    }
+    deflockCount = n;
+    Serial.printf("[VS] Loaded %u Flock cameras from flash\n", deflockCount);
+    return true;
+}
+
+// ============================================================================
+// Deflock sync — FreeRTOS task
+// ============================================================================
+
+/*
+ * Sync strategy (in priority order):
+ *
+ * A) Pi proxy (preferred):
+ *    GET cfg.piProxyURL  → raw binary (uint32 count + N×{float lat, float lon})
+ *    The Pi's deflock_downloader.py already filters for Flock Safety and
+ *    outputs this format directly.
+ *
+ * B) cdn.deflock.me tiles (fallback, requires STA WiFi with internet):
+ *    1. GET cdn.deflock.me/regions/index.json  → manifest
+ *    2. For each tile in the US (all regions containing Flock Safety cameras),
+ *       GET cdn.deflock.me/regions/{lat}/{lon}.json
+ *       Filter nodes where tags.brand == "Flock Safety" OR
+ *                         tags["surveillance:brand"] == "Flock Safety"
+ *    3. Write packed binary to LittleFS
+ *
+ * B is slow (~10 tiles × up to 500 KB each) and may not fit in one session.
+ * Highly recommend using the Pi proxy for regular updates.
+ */
+
+static bool syncViaPiProxy() {
+    if (strlen(cfg.piProxyURL) == 0) return false;
+    Serial.printf("[VS] Trying Pi proxy: %s\n", cfg.piProxyURL);
+    syncMsg = "Connecting to Pi proxy…";
+    syncPct = 10;
+
+    HTTPClient http;
+    http.setTimeout(15000);
+    http.begin(cfg.piProxyURL);
+    int code = http.GET();
+    if (code != 200) {
+        Serial.printf("[VS] Pi proxy HTTP %d\n", code);
+        http.end(); return false;
+    }
+
+    File f = LittleFS.open(DEFLOCK_BIN_PATH ".tmp", "w");
+    if (!f) { http.end(); return false; }
+
+    WiFiClient* stream = http.getStreamPtr();
+    uint8_t buf[512];
+    int total = http.getSize(), received = 0;
+    while (http.connected() && (total == -1 || received < total)) {
+        size_t avail = stream->available();
+        if (!avail) { delay(10); continue; }
+        size_t rd = stream->readBytes(buf, min(avail, sizeof(buf)));
+        f.write(buf, rd);
+        received += (int)rd;
+        if (total > 0) syncPct = 10 + (received * 80) / total;
+    }
+    f.close();
+    http.end();
+
+    if (received < 8) { LittleFS.remove(DEFLOCK_BIN_PATH ".tmp"); return false; }
+    LittleFS.remove(DEFLOCK_BIN_PATH);
+    LittleFS.rename(DEFLOCK_BIN_PATH ".tmp", DEFLOCK_BIN_PATH);
+    return true;
+}
+
+// Check if a CDN tile node's tags indicate Flock Safety
+static bool isFlockSafety(JsonObject tags) {
+    const char* fields[] = { "brand", "surveillance:brand",
+                              "surveillance:manufacturer", "operator" };
+    for (const char* f : fields) {
+        const char* v = tags[f] | "";
+        if (strstr(v, "Flock") || strstr(v, "flock")) return true;
+    }
+    return false;
+}
+
+static bool syncViaCDN() {
+    Serial.println("[VS] Trying cdn.deflock.me tile sync");
+    syncMsg = "Fetching CDN index…";
+    syncPct = 5;
+
+    // Connect STA
+    WiFi.mode(WIFI_AP_STA);
+    WiFi.begin(cfg.staSSID, cfg.staPass);
+    unsigned long t0 = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - t0 < 20000) delay(500);
+    if (WiFi.status() != WL_CONNECTED) {
+        syncMsg = "STA connect failed";
+        WiFi.disconnect(); WiFi.mode(WIFI_AP);
+        return false;
+    }
+
+    // Fetch index
+    HTTPClient http;
+    http.setTimeout(20000);
+    http.begin(DEFLOCK_CDN_INDEX);
+    int code = http.GET();
+    if (code != 200) {
+        http.end(); WiFi.disconnect(); WiFi.mode(WIFI_AP);
+        syncMsg = "CDN index HTTP " + String(code);
+        return false;
+    }
+    JsonDocument idxDoc;
+    deserializeJson(idxDoc, *http.getStreamPtr());
+    http.end();
+
+    JsonArray regions = idxDoc["regions"].as<JsonArray>();
+    int nRegions = regions.size();
+    if (nRegions == 0) {
+        WiFi.disconnect(); WiFi.mode(WIFI_AP);
+        syncMsg = "CDN index empty";
+        return false;
+    }
+
+    File binFile = LittleFS.open(DEFLOCK_BIN_PATH ".tmp", "w");
+    if (!binFile) { WiFi.disconnect(); WiFi.mode(WIFI_AP); return false; }
+    uint32_t count = 0;
+    binFile.write((uint8_t*)&count, 4);   // placeholder for count
+
+    int ri = 0;
+    for (JsonVariant region : regions) {
+        const char* reg = region.as<const char*>();   // e.g. "40/-100"
+        String tileURL = String(DEFLOCK_TILE_BASE) + "/" + reg + ".json";
+
+        syncMsg  = "Tile " + String(++ri) + "/" + String(nRegions) + "…";
+        syncPct  = 10 + (ri * 80) / nRegions;
+        Serial.printf("[VS] Fetching tile %s\n", reg);
+
+        HTTPClient th;
+        th.setTimeout(30000);
+        th.begin(tileURL);
+        int tc = th.GET();
+        if (tc != 200) { th.end(); continue; }
+
+        // Stream-parse the array; each element is {id, lat, lon, tags:{...}}
+        WiFiClient* ts = th.getStreamPtr();
+        JsonDocument tile;
+        DeserializationError err = deserializeJson(tile, *ts);
+        th.end();
+        if (err) continue;
+
+        for (JsonVariant node : tile.as<JsonArray>()) {
+            if (count >= DEFLOCK_MAX_CAMERAS) break;
+            JsonObject tags = node["tags"].as<JsonObject>();
+            if (!isFlockSafety(tags)) continue;
+            CameraPos pos;
+            pos.lat = node["lat"].as<float>();
+            pos.lon = node["lon"].as<float>();
+            if (pos.lat == 0.0f && pos.lon == 0.0f) continue;
+            binFile.write((uint8_t*)&pos, sizeof(pos));
+            count++;
+        }
+        if (count >= DEFLOCK_MAX_CAMERAS) break;
+        delay(200);   // be polite to cdn.deflock.me
+    }
+
+    binFile.seek(0);
+    binFile.write((uint8_t*)&count, 4);
+    binFile.close();
+    WiFi.disconnect(); WiFi.mode(WIFI_AP);
+
+    if (count == 0) {
+        LittleFS.remove(DEFLOCK_BIN_PATH ".tmp");
+        syncMsg = "No Flock cameras found in tiles";
+        return false;
+    }
+    LittleFS.remove(DEFLOCK_BIN_PATH);
+    LittleFS.rename(DEFLOCK_BIN_PATH ".tmp", DEFLOCK_BIN_PATH);
+    Serial.printf("[VS] CDN sync: %u Flock cameras saved\n", count);
+    return true;
+}
+
+static void syncTask(void* /*param*/) {
+    syncState = SS_BUSY;
+    syncPct   = 0;
+
+    bool ok = syncViaPiProxy();
+    if (!ok) ok = syncViaCDN();
+
+    if (ok) {
+        loadDeflockBin();
+        syncMsg   = "Sync complete — " + String(deflockCount) + " cameras";
+        syncState = SS_OK;
+        syncPct   = 100;
+        beep(2000, 80); delay(40); beep(2800, 120);
+    } else {
+        syncMsg   = syncMsg.length() ? syncMsg : "Sync failed";
+        syncState = SS_ERR;
+        syncPct   = 0;
+    }
+    vTaskDelete(nullptr);
+}
+
+static void startSync() {
+    if (syncState == SS_BUSY) return;
+    if (strlen(cfg.piProxyURL) == 0 && strlen(cfg.staSSID) == 0) {
+        syncMsg = "Configure Pi proxy URL or WiFi STA credentials first";
+        syncState = SS_ERR;
+        return;
+    }
+    xTaskCreatePinnedToCore(syncTask, "vs_sync", 20480, nullptr, 1, nullptr, 1);
+}
+
+// ============================================================================
+// Camera init
+// ============================================================================
+
+static bool initCamera() {
+    camera_config_t c = {};
+    c.ledc_channel  = LEDC_CHANNEL_1;
+    c.ledc_timer    = LEDC_TIMER_1;
+    c.pin_d0        = CAM_PIN_D0;   c.pin_d1    = CAM_PIN_D1;
+    c.pin_d2        = CAM_PIN_D2;   c.pin_d3    = CAM_PIN_D3;
+    c.pin_d4        = CAM_PIN_D4;   c.pin_d5    = CAM_PIN_D5;
+    c.pin_d6        = CAM_PIN_D6;   c.pin_d7    = CAM_PIN_D7;
+    c.pin_xclk      = CAM_PIN_XCLK; c.pin_pclk  = CAM_PIN_PCLK;
+    c.pin_vsync     = CAM_PIN_VSYNC; c.pin_href  = CAM_PIN_HREF;
+    c.pin_sccb_sda  = CAM_PIN_SIOD; c.pin_sccb_scl = CAM_PIN_SIOC;
+    c.pin_pwdn      = CAM_PIN_PWDN; c.pin_reset = CAM_PIN_RESET;
+    c.xclk_freq_hz  = 20000000;
+    c.pixel_format  = PIXFORMAT_JPEG;
+    if (psramFound()) {
+        c.frame_size   = FRAMESIZE_VGA;
+        c.jpeg_quality = 12;
+        c.fb_count     = 2;
+        c.fb_location  = CAMERA_FB_IN_PSRAM;
+        c.grab_mode    = CAMERA_GRAB_LATEST;
+    } else {
+        c.frame_size   = FRAMESIZE_QVGA;
+        c.jpeg_quality = 20;
+        c.fb_count     = 1;
+        c.fb_location  = CAMERA_FB_IN_DRAM;
+        c.grab_mode    = CAMERA_GRAB_WHEN_EMPTY;
+    }
+    esp_err_t err = esp_camera_init(&c);
+    if (err != ESP_OK) { Serial.printf("[VS] Camera init err: 0x%x\n", err); return false; }
+    Serial.println("[VS] Camera OK");
+    return true;
+}
+
+// ============================================================================
+// MJPEG server task  (port 81, plain TCP — more reliable than AsyncWebServer
+//                     for continuous streaming connections)
+// ============================================================================
+
+#define MJPEG_BOUNDARY "flockhunter"
+
+static void sendGpsJson(WiFiClient& client) {
+    String body = "{\"valid\":";
+    body += gps.location.isValid() ? "true" : "false";
+    body += ",\"lat\":" + String(gps.location.isValid() ? gps.location.lat() : 0.0, 6);
+    body += ",\"lon\":" + String(gps.location.isValid() ? gps.location.lng() : 0.0, 6);
+    body += ",\"sats\":" + String(gps.satellites.isValid() ? (int)gps.satellites.value() : 0);
+    body += ",\"ts_ms\":" + String(millis()) + "}";
+    client.print("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                 "Access-Control-Allow-Origin: *\r\n"
+                 "Content-Length: " + String(body.length()) + "\r\n\r\n");
+    client.print(body);
+}
+
+static void sendSnapshot(WiFiClient& client) {
+    if (!cameraOK) { client.print("HTTP/1.1 503 Service Unavailable\r\n\r\n"); return; }
+    camera_fb_t* fb = esp_camera_fb_get();
+    if (!fb)       { client.print("HTTP/1.1 500 Internal Server Error\r\n\r\n"); return; }
+    client.printf("HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\n"
+                  "Content-Length: %u\r\nAccess-Control-Allow-Origin: *\r\n\r\n", fb->len);
+    client.write(fb->buf, fb->len);
+    esp_camera_fb_return(fb);
+}
+
+static void streamMjpeg(WiFiClient& client) {
+    if (!cameraOK) { client.print("HTTP/1.1 503 Service Unavailable\r\n\r\n"); return; }
+    client.print("HTTP/1.1 200 OK\r\nContent-Type: multipart/x-mixed-replace;"
+                 "boundary=" MJPEG_BOUNDARY "\r\n"
+                 "Access-Control-Allow-Origin: *\r\n\r\n");
+    while (client.connected()) {
+        camera_fb_t* fb = esp_camera_fb_get();
+        if (!fb) { delay(30); continue; }
+        client.printf("--" MJPEG_BOUNDARY "\r\n"
+                      "Content-Type: image/jpeg\r\nContent-Length: %u\r\n\r\n", fb->len);
+        client.write(fb->buf, fb->len);
+        client.print("\r\n");
+        esp_camera_fb_return(fb);
+        delay(30);   // ~33 fps cap; reduce if CPU-bound
+    }
+}
+
+static void mjpegTask(void* /*param*/) {
+    mjpegServer.begin();
+    Serial.println("[VS] MJPEG server listening on :81");
+    for (;;) {
+        WiFiClient client = mjpegServer.accept();
+        if (!client) { delay(10); continue; }
+
+        // Read the request line
+        String req = client.readStringUntil('\n');
+        // Drain headers
+        while (client.connected()) {
+            String line = client.readStringUntil('\n');
+            if (line == "\r" || line.length() == 0) break;
+        }
+
+        if      (req.indexOf("/stream") >= 0) streamMjpeg(client);
+        else if (req.indexOf("/snap")   >= 0) sendSnapshot(client);
+        else if (req.indexOf("/gps")    >= 0) sendGpsJson(client);
+        else { client.print("HTTP/1.1 404 Not Found\r\n\r\n"); }
+        client.stop();
+    }
+}
+
+// ============================================================================
+// Config web UI HTML  (port 80)
+// ============================================================================
+
+static const char VS_HTML[] PROGMEM = R"html(<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Visual Scout</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font:12px monospace;background:#000;color:#0f0;padding:10px}
+h1{font-size:16px;letter-spacing:2px;margin-bottom:10px;border-bottom:1px solid #0f0;padding-bottom:6px}
+h2{font-size:11px;margin:10px 0 4px;text-transform:uppercase;opacity:.7}
+input[type=text],input[type=password],input[type=number]{
+  width:100%;padding:5px;background:#000;color:#0f0;border:1px solid #0f0;
+  font:12px monospace;margin-bottom:6px}
+button{padding:5px 12px;background:#0f0;color:#000;border:none;font:bold 11px monospace;
+  cursor:pointer;margin:2px 4px 2px 0}
+button:active{background:#fff}
+.ok{color:#0f0}.warn{color:#ff0}.err{color:#f00}
+.card{border:1px solid #0f0;padding:8px;margin-bottom:8px;font-size:11px;line-height:1.8}
+.sm{font-size:10px;opacity:.7}
+</style></head><body>
+<h1>&#x1F4F9; VISUAL SCOUT</h1>
+
+<div class="card" id="gpsCard">GPS: loading…</div>
+<div class="card" id="dbCard">DB: loading…</div>
+<div class="card" id="camCard">Camera: loading…</div>
+
+<h2>Pi Proxy URL <span class="sm">(fastest sync — run pi/deflock_downloader.py first)</span></h2>
+<input type="text" id="pi_proxy" placeholder="http://192.168.0.X:5000/flock_cameras.bin">
+
+<h2>WiFi for direct CDN sync <span class="sm">(fallback if no Pi)</span></h2>
+<input type="text" id="sta_ssid" placeholder="Network SSID">
+<input type="password" id="sta_pass" placeholder="Password">
+
+<h2>Alert Radius (metres)</h2>
+<input type="number" id="radius_m" min="10" max="5000" step="10" value="150">
+
+<div>
+  <button onclick="save()">SAVE</button>
+  <button onclick="syncNow()">SYNC DB</button>
+  <button onclick="location.href='/menu'" style="background:#f00;color:#fff">MENU</button>
+</div>
+<div id="msg" class="sm" style="margin-top:6px"></div>
+
+<script>
+function poll(){
+  fetch('/status').then(r=>r.json()).then(d=>{
+    var gv=d.gps_valid;
+    document.getElementById('gpsCard').innerHTML=
+      '<span class="'+(gv?'ok':'warn')+'">'
+      +(gv?'&#x1F6F0; '+d.gps_lat.toFixed(6)+', '+d.gps_lon.toFixed(6)+
+            ' &bull; '+d.gps_sats+' sats &bull; HDOP '+d.gps_hdop.toFixed(1)
+          :'No GPS fix — check GPIO '+d.gps_rx+'/'+d.gps_tx+' wiring')
+      +'</span>'+(d.last_alert_idx>=0?'<br><span class="warn">&#x26A0; Last alert: camera #'+d.last_alert_idx+' @ '+d.last_alert_dist_m.toFixed(0)+' m</span>':'');
+    var dbOk=d.db_cameras>0;
+    var ss=['Idle','Syncing…','&#x2705; Done','&#x274C; Error'];
+    document.getElementById('dbCard').innerHTML=
+      '<span class="'+(dbOk?'ok':'warn')+'">'+d.db_cameras+' Flock cameras</span>'
+      +(d.sync_state!==0?' &bull; '+ss[d.sync_state]+': '+d.sync_msg+' ('+d.sync_pct+'%)':'');
+    document.getElementById('camCard').innerHTML=
+      d.camera_ok
+        ? '&#x2705; Stream: <a href="http://'+location.hostname+':81/stream" target="_blank" style="color:#0f0">:81/stream</a>'
+          +' &bull; <a href="http://'+location.hostname+':81/snap" target="_blank" style="color:#0f0">snapshot</a>'
+          +' &bull; GPS JSON: <a href="http://'+location.hostname+':81/gps" target="_blank" style="color:#0f0">:81/gps</a>'
+        : '<span class="err">Camera not detected — check CAM_PIN_* wiring</span>';
+  }).catch(()=>{});
+}
+function save(){
+  var b=new URLSearchParams();
+  ['pi_proxy','sta_ssid','sta_pass','radius_m'].forEach(k=>b.append(k,document.getElementById(k).value));
+  fetch('/saveconfig',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:b})
+    .then(r=>r.json()).then(d=>document.getElementById('msg').textContent=d.ok?'Saved!':'Error');
+}
+function syncNow(){
+  document.getElementById('msg').textContent='Sync started…';
+  fetch('/sync').then(r=>r.text()).then(t=>document.getElementById('msg').textContent=t);
+}
+fetch('/cfgvals').then(r=>r.json()).then(d=>{
+  document.getElementById('pi_proxy').value=d.pi_proxy||'';
+  document.getElementById('sta_ssid').value=d.sta_ssid||'';
+  document.getElementById('radius_m').value=d.radius_m||150;
+});
+setInterval(poll,3000); poll();
+</script></body></html>)html";
+
+// ============================================================================
+// Web server endpoints
+// ============================================================================
+
+static void setupWebServer() {
+    cfgServer.on("/", HTTP_GET, [](AsyncWebServerRequest* req) {
+        req->send_P(200, "text/html", VS_HTML);
+    });
+
+    cfgServer.on("/status", HTTP_GET, [](AsyncWebServerRequest* req) {
+        JsonDocument doc;
+        doc["gps_valid"]         = gps.location.isValid();
+        doc["gps_lat"]           = gps.location.isValid() ? gps.location.lat() : 0.0;
+        doc["gps_lon"]           = gps.location.isValid() ? gps.location.lng() : 0.0;
+        doc["gps_sats"]          = gps.satellites.isValid() ? (int)gps.satellites.value() : 0;
+        doc["gps_hdop"]          = gps.hdop.isValid() ? gps.hdop.hdop() : 0.0;
+        doc["gps_rx"]            = GPS_RX_PIN;
+        doc["gps_tx"]            = GPS_TX_PIN;
+        doc["db_cameras"]        = (int)deflockCount;
+        doc["sync_state"]        = (int)syncState;
+        doc["sync_msg"]          = syncMsg;
+        doc["sync_pct"]          = syncPct;
+        doc["alert_radius_m"]    = cfg.alertRadiusM;
+        doc["last_alert_dist_m"] = lastAlertDistM;
+        doc["last_alert_idx"]    = lastAlertIdx;
+        doc["camera_ok"]         = cameraOK;
+        String out; serializeJson(doc, out);
+        req->send(200, "application/json", out);
+    });
+
+    cfgServer.on("/cfgvals", HTTP_GET, [](AsyncWebServerRequest* req) {
+        JsonDocument doc;
+        doc["pi_proxy"] = cfg.piProxyURL;
+        doc["sta_ssid"] = cfg.staSSID;
+        doc["radius_m"] = cfg.alertRadiusM;
+        String out; serializeJson(doc, out);
+        req->send(200, "application/json", out);
+    });
+
+    cfgServer.on("/saveconfig", HTTP_POST, [](AsyncWebServerRequest* req) {
+        if (req->hasParam("pi_proxy", true))
+            strlcpy(cfg.piProxyURL, req->getParam("pi_proxy", true)->value().c_str(), sizeof(cfg.piProxyURL));
+        if (req->hasParam("sta_ssid", true))
+            strlcpy(cfg.staSSID, req->getParam("sta_ssid", true)->value().c_str(), sizeof(cfg.staSSID));
+        if (req->hasParam("sta_pass", true))
+            strlcpy(cfg.staPass, req->getParam("sta_pass", true)->value().c_str(), sizeof(cfg.staPass));
+        if (req->hasParam("radius_m", true))
+            cfg.alertRadiusM = req->getParam("radius_m", true)->value().toFloat();
+        saveConfig();
+        req->send(200, "application/json", "{\"ok\":true}");
+    });
+
+    cfgServer.on("/sync", HTTP_GET, [](AsyncWebServerRequest* req) {
+        startSync();
+        req->send(200, "text/plain", "Sync started");
+    });
+
+    cfgServer.on("/menu", HTTP_GET, [](AsyncWebServerRequest* req) {
+        req->send(200, "text/plain", "Returning to menu…");
+        Preferences p; p.begin("unified-mode", false); p.putInt("mode", 0); p.end();
+        delay(500); ESP.restart();
+    });
+
+    cfgServer.onNotFound([](AsyncWebServerRequest* req) {
+        req->redirect("http://192.168.4.1/");
+    });
+
+    cfgServer.begin();
+    Serial.println("[VS] Config UI on :80  http://192.168.4.1/");
+}
+
+// ============================================================================
+// Proximity check
+// ============================================================================
+
+static void checkProximity() {
+    if (!gps.location.isValid() || deflockCount == 0) return;
+    float myLat = (float)gps.location.lat();
+    float myLon = (float)gps.location.lng();
+    float closest = 1e9f; int ci = -1;
+    for (uint32_t i = 0; i < deflockCount; i++) {
+        float d = haversineM(myLat, myLon, deflockDB[i].lat, deflockDB[i].lon);
+        if (d < closest) { closest = d; ci = (int)i; }
+    }
+    if (ci < 0 || closest > cfg.alertRadiusM) return;
+    unsigned long now = millis();
+    if (ci == lastAlertIdx && (now - lastAlertMs) < ALERT_COOLDOWN_MS) return;
+    lastAlertIdx   = ci;
+    lastAlertDistM = closest;
+    lastAlertMs    = now;
+    Serial.printf("[VS] *** FLOCK CAMERA NEARBY: #%d at %.0f m (%.6f, %.6f) ***\n",
+                  ci, closest, deflockDB[ci].lat, deflockDB[ci].lon);
+    ledOn();
+    beep(1500, 80); delay(40); beep(2000, 80); delay(40); beep(2800, 120);
+    ledOff();
+}
+
+// ============================================================================
+// Arduino entry points  (renamed to setup_ns / loop_ns by wrapper)
+// ============================================================================
+
+void setup() {
+    Serial.println("[VS] ===== VISUAL SCOUT =====");
+
+    if (!LittleFS.begin(true)) Serial.println("[VS] LittleFS failed");
+
+    loadConfig();
+
+    gpsSerial.begin(GPS_BAUD, SERIAL_8N1, GPS_RX_PIN, GPS_TX_PIN);
+    Serial.printf("[VS] GPS on RX=%d TX=%d @%d\n", GPS_RX_PIN, GPS_TX_PIN, GPS_BAUD);
+
+    if (cfg.cameraEnabled) cameraOK = initCamera();
+
+    loadDeflockBin();
+
+    WiFi.persistent(false);
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP("ouispy-scout", "");       // open AP; set password via web UI if desired
+    Serial.printf("[VS] AP: ouispy-scout  http://%s\n", WiFi.softAPIP().toString().c_str());
+
+    setupWebServer();
+
+    // Start MJPEG server in a separate task pinned to core 0
+    xTaskCreatePinnedToCore(mjpegTask, "mjpeg", 8192, nullptr, 5, &mjpegTaskHandle, 0);
+
+    beep(2000, 60); delay(40); beep(2500, 60); delay(40); beep(3000, 100);
+
+    Serial.println("[VS] Stream: http://192.168.4.1:81/stream");
+    Serial.println("[VS] Config: http://192.168.4.1/");
+    if (deflockCount == 0)
+        Serial.println("[VS] No DB — open config UI and press SYNC DB");
+}
+
+void loop() {
+    while (gpsSerial.available()) gps.encode(gpsSerial.read());
+    unsigned long now = millis();
+    if (now - lastProxCheck >= PROXIMITY_CHECK_INTERVAL_MS) {
+        lastProxCheck = now;
+        checkProximity();
+    }
+}
+
+void stop() {
+    if (mjpegTaskHandle) { vTaskDelete(mjpegTaskHandle); mjpegTaskHandle = nullptr; }
+    esp_camera_deinit();
+    gpsSerial.end();
+}

--- a/src/raw/visual_scout.cpp
+++ b/src/raw/visual_scout.cpp
@@ -53,6 +53,7 @@
 #include <ArduinoJson.h>
 #include <TinyGPSPlus.h>
 #include "esp_camera.h"
+#include "sensor.h"
 #include "modes.h"
 
 // ============================================================================
@@ -129,6 +130,7 @@ struct VSConfig {
     char  staPass[64]     = "";
     float alertRadiusM    = ALERT_RADIUS_M_DEFAULT;
     bool  cameraEnabled   = true;
+    bool  cameraHasIrCut  = true;       // true: IR-cut lens, false: no IR-cut lens
     bool  buzzerEnabled   = true;
 };
 static VSConfig cfg;
@@ -202,6 +204,7 @@ static void loadConfig() {
         strlcpy(cfg.staPass,    doc["sta_pass"]    | "", sizeof(cfg.staPass));
         cfg.alertRadiusM  = doc["radius_m"]        | ALERT_RADIUS_M_DEFAULT;
         cfg.cameraEnabled = doc["cam_on"]          | true;
+        cfg.cameraHasIrCut = doc["cam_ir_cut"]     | true;
         cfg.buzzerEnabled = doc["buz_on"]          | true;
     }
     f.close();
@@ -216,6 +219,7 @@ static void saveConfig() {
     doc["sta_pass"] = cfg.staPass;
     doc["radius_m"] = cfg.alertRadiusM;
     doc["cam_on"]   = cfg.cameraEnabled;
+    doc["cam_ir_cut"] = cfg.cameraHasIrCut;
     doc["buz_on"]   = cfg.buzzerEnabled;
     serializeJson(doc, f);
     f.close();
@@ -450,6 +454,28 @@ static void startSync() {
 // Camera init
 // ============================================================================
 
+static void applyCameraProfile() {
+    sensor_t* s = esp_camera_sensor_get();
+    if (!s) return;
+    if (cfg.cameraHasIrCut) {
+        s->set_whitebal(s, 1);
+        s->set_awb_gain(s, 1);
+        s->set_special_effect(s, 0);   // none
+        s->set_saturation(s, 0);
+        s->set_brightness(s, 0);
+        s->set_contrast(s, 0);
+    } else {
+        // No IR-cut lenses run better at night with less color processing.
+        s->set_whitebal(s, 0);
+        s->set_awb_gain(s, 0);
+        s->set_special_effect(s, 2);   // grayscale
+        s->set_saturation(s, -2);
+        s->set_brightness(s, -1);
+        s->set_contrast(s, 1);
+    }
+    Serial.printf("[VS] Camera profile: %s\n", cfg.cameraHasIrCut ? "IR-cut" : "No IR-cut");
+}
+
 static bool initCamera() {
     camera_config_t c = {};
     c.ledc_channel  = LEDC_CHANNEL_1;
@@ -479,6 +505,8 @@ static bool initCamera() {
     }
     esp_err_t err = esp_camera_init(&c);
     if (err != ESP_OK) { Serial.printf("[VS] Camera init err: 0x%x\n", err); return false; }
+    applyCameraProfile();
+
     Serial.println("[VS] Camera OK");
     return true;
 }
@@ -570,6 +598,8 @@ h2{font-size:11px;margin:10px 0 4px;text-transform:uppercase;opacity:.7}
 input[type=text],input[type=password],input[type=number]{
   width:100%;padding:5px;background:#000;color:#0f0;border:1px solid #0f0;
   font:12px monospace;margin-bottom:6px}
+select{width:100%;padding:5px;background:#000;color:#0f0;border:1px solid #0f0;
+  font:12px monospace;margin-bottom:6px}
 button{padding:5px 12px;background:#0f0;color:#000;border:none;font:bold 11px monospace;
   cursor:pointer;margin:2px 4px 2px 0}
 button:active{background:#fff}
@@ -592,6 +622,12 @@ button:active{background:#fff}
 
 <h2>Alert Radius (metres)</h2>
 <input type="number" id="radius_m" min="10" max="5000" step="10" value="150">
+
+<h2>Camera Lens Profile</h2>
+<select id="cam_ir_cut">
+  <option value="1">IR-cut lens (daylight color, recommended default)</option>
+  <option value="0">No IR-cut lens (better NIR flash visibility at night)</option>
+</select>
 
 <div>
   <button onclick="save()">SAVE</button>
@@ -620,12 +656,13 @@ function poll(){
         ? '&#x2705; Stream: <a href="http://'+location.hostname+':81/stream" target="_blank" style="color:#0f0">:81/stream</a>'
           +' &bull; <a href="http://'+location.hostname+':81/snap" target="_blank" style="color:#0f0">snapshot</a>'
           +' &bull; GPS JSON: <a href="http://'+location.hostname+':81/gps" target="_blank" style="color:#0f0">:81/gps</a>'
+          +' &bull; Lens profile: '+(d.cam_ir_cut?'IR-cut':'No IR-cut')
         : '<span class="err">Camera not detected — check CAM_PIN_* wiring</span>';
   }).catch(()=>{});
 }
 function save(){
   var b=new URLSearchParams();
-  ['pi_proxy','sta_ssid','sta_pass','radius_m'].forEach(k=>b.append(k,document.getElementById(k).value));
+  ['pi_proxy','sta_ssid','sta_pass','radius_m','cam_ir_cut'].forEach(k=>b.append(k,document.getElementById(k).value));
   fetch('/saveconfig',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:b})
     .then(r=>r.json()).then(d=>document.getElementById('msg').textContent=d.ok?'Saved!':'Error');
 }
@@ -637,6 +674,7 @@ fetch('/cfgvals').then(r=>r.json()).then(d=>{
   document.getElementById('pi_proxy').value=d.pi_proxy||'';
   document.getElementById('sta_ssid').value=d.sta_ssid||'';
   document.getElementById('radius_m').value=d.radius_m||150;
+  document.getElementById('cam_ir_cut').value=d.cam_ir_cut?'1':'0';
 });
 setInterval(poll,3000); poll();
 </script></body></html>)html";
@@ -667,6 +705,7 @@ static void setupWebServer() {
         doc["last_alert_dist_m"] = lastAlertDistM;
         doc["last_alert_idx"]    = lastAlertIdx;
         doc["camera_ok"]         = cameraOK;
+        doc["cam_ir_cut"]        = cfg.cameraHasIrCut;
         String out; serializeJson(doc, out);
         req->send(200, "application/json", out);
     });
@@ -676,6 +715,7 @@ static void setupWebServer() {
         doc["pi_proxy"] = cfg.piProxyURL;
         doc["sta_ssid"] = cfg.staSSID;
         doc["radius_m"] = cfg.alertRadiusM;
+        doc["cam_ir_cut"] = cfg.cameraHasIrCut;
         String out; serializeJson(doc, out);
         req->send(200, "application/json", out);
     });
@@ -689,7 +729,10 @@ static void setupWebServer() {
             strlcpy(cfg.staPass, req->getParam("sta_pass", true)->value().c_str(), sizeof(cfg.staPass));
         if (req->hasParam("radius_m", true))
             cfg.alertRadiusM = req->getParam("radius_m", true)->value().toFloat();
+        if (req->hasParam("cam_ir_cut", true))
+            cfg.cameraHasIrCut = req->getParam("cam_ir_cut", true)->value() != "0";
         saveConfig();
+        if (cameraOK) applyCameraProfile();
         req->send(200, "application/json", "{\"ok\":true}");
     });
 
@@ -783,7 +826,7 @@ void loop() {
     }
 }
 
-void stop() {
+void modeStop() {
     if (mjpegTaskHandle) { vTaskDelete(mjpegTaskHandle); mjpegTaskHandle = nullptr; }
     esp_camera_deinit();
     gpsSerial.end();


### PR DESCRIPTION
## Overview

Adds **Mode 7: Visual Scout** — a new unified mode that catches Flock Safety cameras two ways simultaneously:

1. **RF-silent cameras** — GPS proximity alerting against the full DeFlock database (known camera positions)
2. **New/unknown cameras** — MJPEG stream to a Raspberry Pi 5 + Coral TPU running YOLOv8 visual detection

---

## ESP32 Changes

### `src/raw/visual_scout.cpp` + `src/mode_visual_scout.cpp`

| Feature | Detail |
|---------|--------|
| **GPS** | TinyGPSPlus on UART2 (GPIO 44 RX / 43 TX, 9600 baud) |
| **Deflock DB sync** | Pi proxy (preferred) → cdn.deflock.me tiled CDN fallback |
| **DB format** | Compact binary in LittleFS: `uint32 count` + `N × {float lat, float lon}` |
| **Proximity alert** | Haversine check every 2 s — buzzer + LED within configurable radius (default 150 m) |
| **Camera stream** | OV2640 MJPEG on port 81 (`/stream`, `/snap`, `/gps`) |
| **Config UI** | AsyncWebServer on port 80 at `http://192.168.4.1` |

### `src/main.cpp` / `src/modes.h` / `platformio.ini`

- Mode range extended to 1–7; mode 7 wired into setup/loop dispatch
- Selector UI updated with Visual Scout entry
- Added `espressif/esp32-camera@^2.0.14` dependency

---

## Raspberry Pi Pipeline (`pi/`)

### `pi/deflock_downloader.py`
- Downloads ~117K ALPR cameras from `data.dontgetflocked.com` / `cdn.deflock.me`
- Filters to **Flock Safety only** (~20–30K cameras)
- Serves compact binary at `http://<pi>:5000/flock_cameras.bin` for ESP32 fetch
- Periodic re-sync (default 6 h), designed to run as systemd service

### `pi/flock_detector.py`
- Streams MJPEG from ESP32, decodes with OpenCV
- Runs **YOLOv8n** (CPU) or compiled **.tflite on Coral Edge TPU** via pycoral
- Saves annotated frames + GPS JSON sidecars to NVMe SSD (`/mnt/ssd/training_data/`)
- Background upload thread for crowd-sourced training data contribution

### `pi/SETUP.md`
Full guide: NVMe mount, Coral TPU runtime install, model conversion with `edgetpu_compiler`, systemd service configs.

---

## Detection Flow

```
Drive past area
  ├── ESP32 passive WiFi/BLE sniffs (existing modes 1–6)
  ├── ESP32 GPS → alert on known Flock cameras (DeFlock DB)
  └── ESP32 camera stream → Pi + Coral TPU → detect NEW/silent cameras
                                            → save to NVMe with GPS tags
                                            → upload → retrain → share model
```

---

## Hardware Required for Mode 7

| Component | GPIO / Interface |
|-----------|-----------------|
| GPS module (9600 baud NMEA) | GPIO 44 (RX) ← GPS TX |
| OV2640 camera | See `CAM_PIN_*` defines in `visual_scout.cpp` |
| Raspberry Pi 5 | Connected to ESP32 AP (`ouispy-scout`) |
| Google Coral TPU (USB or M.2) | Optional — falls back to CPU YOLOv8 |
| NVMe SSD via Pi 5 M.2 HAT | Training data storage |

---

## Notes

- The AP `ouispy-scout` is **open by default** (no WPA2 password) so the Pi can join without pre-configuration. Set a password via the web UI if needed.
- Camera pin defaults match a common ESP32-S3 WROOM + OV2640 FPC breakout. Adjust `CAM_PIN_*` in `visual_scout.cpp` for your specific PCB.
- The DeFlock CDN sync (`cdn.deflock.me`) filters tiles to Flock Safety brand only, so no non-Flock cameras are stored on the ESP32.